### PR TITLE
fix: clean filter fails closed — never emit plaintext on encryption error

### DIFF
--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -18,10 +18,10 @@ logger = logging.getLogger(__name__)
 class EncryptionManager:
     @injector.inject
     def __init__(
-            self,
-            git_attributes_parser: GitAttributesParser,
-            key_manager: AesKeyManager,
-            key_rotator: KeyRotator
+        self,
+        git_attributes_parser: GitAttributesParser,
+        key_manager: AesKeyManager,
+        key_rotator: KeyRotator,
     ):
         self.git_attributes_parser = git_attributes_parser
         self.key_manager = key_manager
@@ -59,12 +59,16 @@ class EncryptionManager:
     def encrypt_files(self, filter_name: str):
         try:
             logger.info("Encrypting files for filter: %s", filter_name)
-            files_to_encrypt = self.git_attributes_parser.get_files_for_filter(filter_name=filter_name)
+            files_to_encrypt = self.git_attributes_parser.get_files_for_filter(
+                filter_name=filter_name
+            )
             if not files_to_encrypt:
                 logging.info(f"No files to encrypt for filter: {filter_name}")
                 return
 
-            self.__get_encryption_handler(filter_name=filter_name).encrypt_files(files=files_to_encrypt)
+            self.__get_encryption_handler(filter_name=filter_name).encrypt_files(
+                files=files_to_encrypt
+            )
             logging.info(f"Successfully encrypted files for filter: {filter_name}")
             print(f"Successfully encrypted files for filter: {filter_name}")
         except Exception as e:
@@ -74,12 +78,16 @@ class EncryptionManager:
     def decrypt_files(self, filter_name: str):
         try:
             logger.info("Decrypting files for filter: %s", filter_name)
-            files_to_decrypt = self.git_attributes_parser.get_files_for_filter(filter_name=filter_name)
+            files_to_decrypt = self.git_attributes_parser.get_files_for_filter(
+                filter_name=filter_name
+            )
             if not files_to_decrypt:
                 logging.info(f"No files to decrypt for filter: {filter_name}")
                 return
 
-            self.__get_encryption_handler(filter_name=filter_name).decrypt_files(files=files_to_decrypt)
+            self.__get_encryption_handler(filter_name=filter_name).decrypt_files(
+                files=files_to_decrypt
+            )
             logging.info(f"Successfully decrypted files for filter: {filter_name}")
             print(f"Successfully decrypted files for filter: {filter_name}")
         except Exception as e:
@@ -95,22 +103,27 @@ class EncryptionManager:
             return
 
         try:
-            filter_name = self.git_attributes_parser.get_filter_name_for_file(file_name=file_name)
+            filter_name = self.git_attributes_parser.get_filter_name_for_file(
+                file_name=file_name
+            )
             logger.debug("Found filter_name to decrypt: %s", filter_name)
 
             if filter_name is None:
                 logger.error("No filter found for file: %s", file_name)
-                return
+                sys.exit(1)
 
-            encrypted_data = self.__get_encryption_handler(filter_name=filter_name).encrypt_data(input_data)
+            encrypted_data = self.__get_encryption_handler(
+                filter_name=filter_name
+            ).encrypt_data(input_data)
 
             sys.stdout.buffer.write(encrypted_data)
             sys.stdout.buffer.flush()
-            logging.info(f"Successfully encrypted data from stdin for file: {file_name}")
+            logging.info(
+                f"Successfully encrypted data from stdin for file: {file_name}"
+            )
         except Exception as e:
             logging.error(f"Encrypt data command failed: {e}", exc_info=True)
-            sys.stdout.buffer.write(input_data)
-            sys.stdout.buffer.flush()
+            sys.exit(1)
 
     def decrypt_stdin(self, file_name):
         logging.info(f"Decrypting data from stdin for file: {file_name}")
@@ -128,12 +141,16 @@ class EncryptionManager:
                 logger.error("No filter found for file: %s", file_name)
                 return
 
-            decrypted_data = self.__get_encryption_handler(filter_name=filter_name).decrypt_data(encrypted_data)
+            decrypted_data = self.__get_encryption_handler(
+                filter_name=filter_name
+            ).decrypt_data(encrypted_data)
             logger.debug("Decrypted file: %s", file_name)
 
             sys.stdout.buffer.write(decrypted_data)
             sys.stdout.buffer.flush()
-            logging.info(f"Successfully decrypted data from stdin for file: {file_name}")
+            logging.info(
+                f"Successfully decrypted data from stdin for file: {file_name}"
+            )
         except Exception as e:
             logging.error(f"Decrypt data command failed: {e}", exc_info=True)
             sys.stdout.buffer.write(encrypted_data)
@@ -156,7 +173,9 @@ class EncryptionManager:
             try:
                 self.encrypt_files(filter_name=filter_name)
             except Exception as e:
-                logger.warning("Failed to encrypt files for filter '%s': %s", filter_name, e)
+                logger.warning(
+                    "Failed to encrypt files for filter '%s': %s", filter_name, e
+                )
 
             self.key_manager.remove_key_iv_from_cache(filter_name=filter_name)
             logger.info("Successfully cleaned staged data for filter: %s", filter_name)
@@ -201,29 +220,63 @@ class EncryptionManager:
     @staticmethod
     def __init_filter(filter_name: str):
         # Check for existing Git filters
-        check_clean = subprocess.getoutput(f'git config --get filter.{filter_name}.clean')
-        check_smudge = subprocess.getoutput(f'git config --get filter.{filter_name}.smudge')
+        check_clean = subprocess.getoutput(
+            f"git config --get filter.{filter_name}.clean"
+        )
+        check_smudge = subprocess.getoutput(
+            f"git config --get filter.{filter_name}.smudge"
+        )
 
         logger.info("Setting up Git filters for '%s'", filter_name)
         if check_clean or check_smudge:
+            subprocess.run(
+                ["git", "config", f"filter.{filter_name}.required", "true"], check=True
+            )
             sys.stdout.buffer.write(
-                f"Git filters for '{filter_name}' already exist. Skipping filter setup.".encode('utf-8') + b'\n')
+                f"Git filters for '{filter_name}' already exist. Skipping filter setup.".encode(
+                    "utf-8"
+                )
+                + b"\n"
+            )
             sys.stdout.buffer.flush()
             return
 
         # Set Git filters
-        subprocess.run(['git', 'config', f'filter.{filter_name}.clean', 'git-secret-protector encrypt %f'], check=True)
-        subprocess.run(['git', 'config', f'filter.{filter_name}.smudge', 'git-secret-protector decrypt %f'], check=True)
-        subprocess.run(['git', 'config', f'filter.{filter_name}.required', 'true'], check=True)
-        logger.debug("Git clean & smudge filters for '%s' have been set up successfully.", filter_name)
+        subprocess.run(
+            [
+                "git",
+                "config",
+                f"filter.{filter_name}.clean",
+                "git-secret-protector encrypt %f",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "config",
+                f"filter.{filter_name}.smudge",
+                "git-secret-protector decrypt %f",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", f"filter.{filter_name}.required", "true"], check=True
+        )
+        logger.debug(
+            "Git clean & smudge filters for '%s' have been set up successfully.",
+            filter_name,
+        )
 
     def __get_encryption_handler(self, filter_name: str):
         aes_key, iv = self.key_manager.retrieve_key_and_iv(filter_name)
-        return AesEncryptionHandler(aes_key=aes_key, iv=iv, magic_header=self.magic_header)
+        return AesEncryptionHandler(
+            aes_key=aes_key, iv=iv, magic_header=self.magic_header
+        )
 
     def __is_encrypted(self, file_path: str):
         try:
-            with open(file_path, 'rb') as file:
+            with open(file_path, "rb") as file:
                 header = file.read(len(self.magic_header))
                 return header == self.magic_header
         except IOError:

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -1,6 +1,8 @@
 import base64
+import io
 import secrets
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from Crypto.Cipher import AES
@@ -8,12 +10,13 @@ from Crypto.Util.Padding import pad
 
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
 from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
+from git_secret_protector.services.encryption_manager import EncryptionManager
 from tests.utils.random_utils import generate_random_string
 
 
 class TestEncryptionManager(unittest.TestCase):
 
-    @patch('git_secret_protector.crypto.aes_key_manager.get_settings')
+    @patch("git_secret_protector.crypto.aes_key_manager.get_settings")
     def setUp(self, mock_get_settings):
         self.mock_settings = MagicMock()
         self.magic_header = generate_random_string()
@@ -23,12 +26,18 @@ class TestEncryptionManager(unittest.TestCase):
         self.aes_key = secrets.token_bytes(16)
         self.iv = secrets.token_bytes(AES.block_size)
 
-        self.manager = AesEncryptionHandler(aes_key=self.aes_key, iv=self.iv,
-                                            magic_header=self.mock_settings.magic_header.encode())
+        self.manager = AesEncryptionHandler(
+            aes_key=self.aes_key,
+            iv=self.iv,
+            magic_header=self.mock_settings.magic_header.encode(),
+        )
         self.cipher = AES.new(self.aes_key, AES.MODE_CBC, self.iv)
 
         self.mock_git_attributes_parser = MagicMock(spec=GitAttributesParser)
-        self.mock_git_attributes_parser.get_files_for_filter.return_value = ['file1.txt', 'file2.txt']
+        self.mock_git_attributes_parser.get_files_for_filter.return_value = [
+            "file1.txt",
+            "file2.txt",
+        ]
 
     def test_decrypt_data(self):
         test_data = secrets.token_bytes(128)  # Generating 128 bytes of random data
@@ -39,28 +48,30 @@ class TestEncryptionManager(unittest.TestCase):
         data_with_header = self.magic_header.encode() + encrypted_data_base64
 
         decrypted_data = self.manager.decrypt_data(data_with_header)
-        self.assertEqual(decrypted_data, test_data, "Decrypted data does not match the original")
+        self.assertEqual(
+            decrypted_data, test_data, "Decrypted data does not match the original"
+        )
 
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
     def test_encrypt_file(self, mock_open):
-        test_data = b'This is some test data'
+        test_data = b"This is some test data"
         mock_open.return_value.read.return_value = test_data
 
         # Generate a random path
-        dummy_path = '/tmp/' + secrets.token_hex(10)
+        dummy_path = "/tmp/" + secrets.token_hex(10)
         mock_open.return_value.read.return_value = test_data
 
         self.manager.encrypt_file(dummy_path)
 
         mock_open().write.assert_called_once_with(self.manager.encrypt_data(test_data))
 
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
     def test_decrypt_file(self, mock_open):
-        test_data = b'This is some test data'
+        test_data = b"This is some test data"
 
         file_data = self.manager.encrypt_data(data=test_data)
 
-        dummy_path = '/tmp/' + secrets.token_hex(10)
+        dummy_path = "/tmp/" + secrets.token_hex(10)
         mock_open.return_value.read.return_value = file_data
 
         self.manager.decrypt_file(dummy_path)
@@ -68,5 +79,93 @@ class TestEncryptionManager(unittest.TestCase):
         mock_open().write.assert_called_once_with(test_data)
 
 
-if __name__ == '__main__':
+class TestEncryptionManagerService(unittest.TestCase):
+
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def setUp(self, mock_get_settings):
+        mock_settings = MagicMock()
+        mock_settings.magic_header = generate_random_string()
+        mock_get_settings.return_value = mock_settings
+
+        self.git_attributes_parser = MagicMock(spec=GitAttributesParser)
+        self.key_manager = MagicMock()
+        self.key_rotator = MagicMock()
+        self.manager = EncryptionManager(
+            git_attributes_parser=self.git_attributes_parser,
+            key_manager=self.key_manager,
+            key_rotator=self.key_rotator,
+        )
+
+    def test_encrypt_stdin_exits_non_zero_and_writes_nothing_when_encryption_raises(
+        self,
+    ):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+
+        with patch.object(
+            self.manager,
+            "_EncryptionManager__get_encryption_handler",
+            side_effect=RuntimeError("boom"),
+        ):
+            stdout_buffer = io.BytesIO()
+            stdin = SimpleNamespace(buffer=io.BytesIO(b"plain-secret"))
+            stdout = SimpleNamespace(buffer=stdout_buffer)
+
+            with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+                with self.assertRaises(SystemExit) as context:
+                    self.manager.encrypt_stdin("secrets.env")
+
+        self.assertNotEqual(context.exception.code, 0)
+        self.assertEqual(stdout_buffer.getvalue(), b"")
+
+    def test_encrypt_stdin_exits_non_zero_when_no_filter_matches(self):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = None
+        stdout_buffer = io.BytesIO()
+        stdin = SimpleNamespace(buffer=io.BytesIO(b"plain-secret"))
+        stdout = SimpleNamespace(buffer=stdout_buffer)
+
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            with self.assertRaises(SystemExit) as context:
+                self.manager.encrypt_stdin("secrets.env")
+
+        self.assertNotEqual(context.exception.code, 0)
+        self.assertEqual(stdout_buffer.getvalue(), b"")
+
+    def test_encrypt_stdin_writes_ciphertext_on_success(self):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+        handler = MagicMock()
+        handler.encrypt_data.return_value = b"ciphertext"
+        stdout_buffer = io.BytesIO()
+        stdin = SimpleNamespace(buffer=io.BytesIO(b"plain-secret"))
+        stdout = SimpleNamespace(buffer=stdout_buffer)
+
+        with patch.object(
+            self.manager,
+            "_EncryptionManager__get_encryption_handler",
+            return_value=handler,
+        ):
+            with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+                self.manager.encrypt_stdin("secrets.env")
+
+        self.assertEqual(stdout_buffer.getvalue(), b"ciphertext")
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    @patch("git_secret_protector.services.encryption_manager.subprocess.getoutput")
+    def test_setup_filters_sets_required_for_existing_filter(
+        self, mock_getoutput, mock_run
+    ):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        mock_getoutput.side_effect = [
+            "git-secret-protector encrypt %f",
+            "git-secret-protector decrypt %f",
+        ]
+
+        self.manager.setup_filters()
+
+        mock_run.assert_called_once_with(
+            ["git", "config", "filter.secret.required", "true"],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

### Why
The git **clean** filter fails *open*: on any encryption error (`encrypt_stdin`) it wrote the raw plaintext to stdout and exited 0, so git silently staged secrets in cleartext. Reproduced: a repo with `filter.required = true` and no key available staged `AWS_SECRET_ACCESS_KEY=…` in plaintext at exit 0.

### What
- Clean path now **fails closed**: on a missing filter or any encryption error, it writes nothing and exits non-zero.
- `setup-filters` now enforces `filter.<name>.required = true` on **already-configured** filters (previously only on first setup), so git actually aborts the add/commit when clean fails.
- **Smudge unchanged** — stays fail-safe (exit 0), so a missing key never blocks checkout.

### Solution
```mermaid
flowchart LR
  A[git add secret] --> B[clean filter: encrypt_stdin]
  B --> C{encrypt ok?}
  C -->|yes| D[emit ciphertext, exit 0]
  C -->|no, before| E["emit PLAINTEXT, exit 0 → secret committed"]
  C -->|no, after| F["emit nothing, exit≠0 → git aborts (required=true)"]
```
Control-flow only — no change to crypto, `magic_header`, stored keys, or storage backends. Existing encrypted files and keys are unaffected; the success path is byte-identical.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- `poetry run pytest tests/unit/test_encryption_manager.py` — 7 passed. New tests cover: clean exits non-zero + writes nothing when encryption raises; exits non-zero when no filter matches; success emits ciphertext; `required=true` set on the existing-filter path.
- End-to-end: in a temp repo with `setup-filters` (required=true) and no key, `git add` now aborts (`fatal: clean filter failed`, exit 128) and **nothing is staged** — vs. plaintext staged before this change.

## Related Issues
Suggested CHANGELOG entry for the release:
> **Security (clean filter fails closed):** the clean filter no longer emits plaintext on an encryption error; it writes nothing and exits non-zero. `setup-filters` enforces `required = true` on existing filters so git aborts a failed clean. Smudge remains fail-safe.