### PR TITLE
fix: v1 security hardening (exit codes, no-shell git config, 0600 key cache, lazy SDK imports)

### DIFF
--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -144,9 +144,12 @@ class AesKeyManager:
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
             0o600,
         )
+        # Lock mode to 0600 on the fd before writing — O_CREAT ignores the mode
+        # for a pre-existing file, so without this the secret would briefly land
+        # under the old (e.g. 0644) permissions.
+        os.fchmod(cache_fd, 0o600)
         with os.fdopen(cache_fd, "w") as cache_file:
             cache_file.write(json_data)
-        os.chmod(cache_path, 0o600)
         logger.debug("Cached AES key and IV locally for filter: %s", filter_name)
 
     def load_key_iv_from_cache(self, filter_name: str):

--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -25,7 +25,9 @@ class AesKeyManager:
     def _get_storage_manager(self):
         if self.storage_manager is None:
             storage_type = self.settings.storage_type.value
-            self.storage_manager = StorageManagerFactory.create(storage_type=storage_type)
+            self.storage_manager = StorageManagerFactory.create(
+                storage_type=storage_type
+            )
         return self.storage_manager
 
     """
@@ -48,24 +50,31 @@ class AesKeyManager:
 
             if self._parameter_exists(parameter_name=parameter_name):
                 logger.error(
-                    f"Parameter with name {parameter_name} already exists. Use a different filter name or manually delete the existing parameter.")
-                raise ValueError(f"Parameter with name {parameter_name} already exists.")
+                    f"Parameter with name {parameter_name} already exists. Use a different filter name or manually delete the existing parameter."
+                )
+                raise ValueError(
+                    f"Parameter with name {parameter_name} already exists."
+                )
 
             aes_key = os.urandom(self.AES_KEY_SIZE)
             iv = os.urandom(self.IV_SIZE)
 
             data = {
-                'aes_key': base64.b64encode(s=aes_key).decode(encoding='utf-8'),
-                'iv': base64.b64encode(s=iv).decode(encoding='utf-8')
+                "aes_key": base64.b64encode(s=aes_key).decode(encoding="utf-8"),
+                "iv": base64.b64encode(s=iv).decode(encoding="utf-8"),
             }
             json_data = json.dumps(obj=data)
 
             self._get_storage_manager().store(parameter_name, json_data)
 
-            logger.info(f"AES key and IV setup and stored in storage for filter: {filter_name}")
+            logger.info(
+                f"AES key and IV setup and stored in storage for filter: {filter_name}"
+            )
             self.cache_key_iv_locally(filter_name, json_data)
         except Exception as e:
-            raise AesKeyError(f"Failed to setup AES key and IV for filter '{filter_name}': {str(e)}")
+            raise AesKeyError(
+                f"Failed to setup AES key and IV for filter '{filter_name}': {str(e)}"
+            )
 
     """
     Destroys the AES key and initialization vector (IV) associated with the given filter name.
@@ -86,16 +95,22 @@ class AesKeyManager:
         try:
             local_data = self.load_key_iv_from_cache(filter_name=filter_name)
             if local_data:
-                logger.debug("Using locally cached AES key and IV for filter: %s", filter_name)
-                return base64.b64decode(local_data['aes_key']), base64.b64decode(local_data['iv'])
+                logger.debug(
+                    "Using locally cached AES key and IV for filter: %s", filter_name
+                )
+                return base64.b64decode(local_data["aes_key"]), base64.b64decode(
+                    local_data["iv"]
+                )
 
             parameter_name = self._parameter_name(filter_name=filter_name)
             data = json.loads(self._get_storage_manager().retrieve(name=parameter_name))
             self.cache_key_iv_locally(filter_name, json.dumps(data))
 
-            return base64.b64decode(data['aes_key']), base64.b64decode(data['iv'])
+            return base64.b64decode(data["aes_key"]), base64.b64decode(data["iv"])
         except Exception as e:
-            raise AesKeyError(f"Failed to retrieve AES key and IV for filter '{filter_name}': {str(e)}")
+            raise AesKeyError(
+                f"Failed to retrieve AES key and IV for filter '{filter_name}': {str(e)}"
+            )
 
     """
     Clears the locally cached AES key and initialization vector (IV) associated with the given filter name.
@@ -113,22 +128,32 @@ class AesKeyManager:
         try:
             parameter_name = self._parameter_name(filter_name=filter_name)
             self._get_storage_manager().delete(name=parameter_name)
-            logger.info(f"Successfully destroyed AES key and IV in storage for filter: {filter_name}")
+            logger.info(
+                f"Successfully destroyed AES key and IV in storage for filter: {filter_name}"
+            )
         except Exception as e:
-            raise AesKeyError(f"Failed to destroy AES key and IV for filter '{filter_name}': {str(e)}")
+            raise AesKeyError(
+                f"Failed to destroy AES key and IV for filter '{filter_name}': {str(e)}"
+            )
 
     def cache_key_iv_locally(self, filter_name: str, json_data: str):
         cache_path = self._cache_path(filter_name=filter_name)
 
-        with open(cache_path, 'w') as cache_file:
+        cache_fd = os.open(
+            cache_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(cache_fd, "w") as cache_file:
             cache_file.write(json_data)
+        os.chmod(cache_path, 0o600)
         logger.debug("Cached AES key and IV locally for filter: %s", filter_name)
 
     def load_key_iv_from_cache(self, filter_name: str):
         cache_path = self._cache_path(filter_name=filter_name)
 
         if os.path.exists(cache_path):
-            with open(cache_path, 'r') as cache_file:
+            with open(cache_path, "r") as cache_file:
                 json_data = cache_file.read()
                 data = json.loads(json_data)
                 return data
@@ -149,11 +174,15 @@ class AesKeyManager:
         try:
             return self._get_storage_manager().exists(parameter_name)
         except Exception as e:
-            logger.error(f"Error while checking existence of parameter {parameter_name}: {e}")
+            logger.error(
+                f"Error while checking existence of parameter {parameter_name}: {e}"
+            )
             return False
 
     def _parameter_name(self, filter_name) -> str:
-        return self._get_storage_manager().parameter_name(module_name=self.module_name, filter_name=filter_name)
+        return self._get_storage_manager().parameter_name(
+            module_name=self.module_name, filter_name=filter_name
+        )
 
     def _cache_path(self, filter_name: str) -> str:
         return os.path.join(self.cache_dir, f"{filter_name}_key_iv.json")

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -7,31 +7,47 @@ from git_secret_protector.core.settings import get_settings
 from git_secret_protector.services.encryption_manager import EncryptionManager
 from git_secret_protector.utils.configure_logging import configure_logging
 
-MODULE_FOLDER = '.git_secret_protector'
+MODULE_FOLDER = ".git_secret_protector"
 
-inj = GitSecretProtectorModule.get_injector()
-manager = inj.get(EncryptionManager)
+manager = None
 
 
 def init_module_folder():
-    module_path = Path(get_settings().module_dir)
+    settings = get_settings()
+    module_path = Path(settings.module_dir)
 
     if not module_path.exists():
         module_path.mkdir(parents=True, exist_ok=True)
-        (module_path / 'cache').mkdir(exist_ok=True)
-        (module_path / 'logs').mkdir(exist_ok=True)
+        (module_path / "cache").mkdir(exist_ok=True)
+        (module_path / "logs").mkdir(exist_ok=True)
+    else:
+        (module_path / "cache").mkdir(exist_ok=True)
+        (module_path / "logs").mkdir(exist_ok=True)
+
+    gitignore_path = Path(settings.base_dir) / ".gitignore"
+    gitignore_entry = f"{MODULE_FOLDER}/"
+    existing_lines = []
+
+    if gitignore_path.exists():
+        existing_lines = gitignore_path.read_text().splitlines()
+
+    if gitignore_entry not in existing_lines:
+        with open(gitignore_path, "a") as gitignore_file:
+            if gitignore_path.exists() and gitignore_path.stat().st_size > 0:
+                gitignore_file.write("\n")
+            gitignore_file.write(f"{gitignore_entry}\n")
 
     # Check if config.ini exists, if not, create it with default settings
-    config_file = module_path / 'config.ini'
+    config_file = module_path / "config.ini"
     if not config_file.exists():
         config = configparser.ConfigParser()
-        config['DEFAULT'] = {
-            'module_name': 'git-secret-protector',
-            'log_level': 'WARN',
-            'log_max_size': '1048576'  # 10MB
+        config["DEFAULT"] = {
+            "module_name": "git-secret-protector",
+            "log_level": "WARN",
+            "log_max_size": "1048576",  # 10MB
         }
 
-        with open(config_file, 'w') as configfile:
+        with open(config_file, "w") as configfile:
             config.write(configfile)
 
 
@@ -89,59 +105,83 @@ def status_command(_):
 
 
 def show_project_version(_):
-    manager.show_project_version()
+    EncryptionManager.show_project_version()
 
 
 def main():
-    init_module_folder()
-
-    configure_logging()
     parser = argparse.ArgumentParser(description="Git Secret Protector CLI")
     subparsers = parser.add_subparsers(help="Available commands")
 
     # Add filter commands to the parser
     filter_commands = [
-        ('setup-aes-key', setup_aes_key, "Set up AES key for a filter"),
-        ('pull-aes-key', pull_aes_key, "Pull AES key for a filter"),
-        ('rotate-key', rotate_key, "Rotate AES key and re-encrypt secrets"),
-        ('decrypt-files', decrypt_files_by_filter, "Decrypt files for a specific filter"),
-        ('encrypt-files', encrypt_files_by_filter, "Encrypt all files for a specified filter"),
-        ('clean-filter', clean_filter, "Clean staged data for a specified filter")
+        ("setup-aes-key", setup_aes_key, "Set up AES key for a filter"),
+        ("pull-aes-key", pull_aes_key, "Pull AES key for a filter"),
+        ("rotate-key", rotate_key, "Rotate AES key and re-encrypt secrets"),
+        (
+            "decrypt-files",
+            decrypt_files_by_filter,
+            "Decrypt files for a specific filter",
+        ),
+        (
+            "encrypt-files",
+            encrypt_files_by_filter,
+            "Encrypt all files for a specified filter",
+        ),
+        ("clean-filter", clean_filter, "Clean staged data for a specified filter"),
     ]
 
     # Command to set up Git filters
-    parser_setup_filters_stdin = subparsers.add_parser('setup-filters', help="Set up Git filters in Git config")
+    parser_setup_filters_stdin = subparsers.add_parser(
+        "setup-filters", help="Set up Git filters in Git config"
+    )
     parser_setup_filters_stdin.set_defaults(func=setup_filters)
 
     # Command to decrypt data from stdin
-    parser_decrypt_stdin = subparsers.add_parser('decrypt', help="Decrypt data from stdin")
-    parser_decrypt_stdin.add_argument('file_name', type=str, help="Filename for decryption")
+    parser_decrypt_stdin = subparsers.add_parser(
+        "decrypt", help="Decrypt data from stdin"
+    )
+    parser_decrypt_stdin.add_argument(
+        "file_name", type=str, help="Filename for decryption"
+    )
     parser_decrypt_stdin.set_defaults(func=decrypt_stdin)
 
     # Command to encrypt data from stdin
-    parser_encrypt_stdin = subparsers.add_parser('encrypt', help="Encrypt data from stdin")
-    parser_encrypt_stdin.add_argument('file_name', type=str, help="Filename for encryption")
+    parser_encrypt_stdin = subparsers.add_parser(
+        "encrypt", help="Encrypt data from stdin"
+    )
+    parser_encrypt_stdin.add_argument(
+        "file_name", type=str, help="Filename for encryption"
+    )
     parser_encrypt_stdin.set_defaults(func=encrypt_stdin)
 
     for cmd_name, func, help_text in filter_commands:
         parser_cmd = subparsers.add_parser(cmd_name, help=help_text)
-        parser_cmd.add_argument('filter_name', type=str, nargs='?', help="The filter name")
+        parser_cmd.add_argument(
+            "filter_name", type=str, nargs="?", help="The filter name"
+        )
         parser_cmd.set_defaults(func=func)
 
     # Status command
-    parser_status = subparsers.add_parser('status', help="List all filters and file statuses")
+    parser_status = subparsers.add_parser(
+        "status", help="List all filters and file statuses"
+    )
     parser_status.set_defaults(func=status_command)
 
     # Version command
-    parser_status = subparsers.add_parser('version', help="Show version")
+    parser_status = subparsers.add_parser("version", help="Show version")
     parser_status.set_defaults(func=show_project_version)
 
     args = parser.parse_args()
-    if hasattr(args, 'func'):
+    if hasattr(args, "func"):
+        if args.func is not show_project_version:
+            init_module_folder()
+            configure_logging()
+            global manager
+            manager = GitSecretProtectorModule.get_injector().get(EncryptionManager)
         args.func(args)
     else:
         parser.print_help()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -37,6 +37,7 @@ class EncryptionManager:
         except Exception as e:
             logger.error(f"AES key setup command failed: {e}", exc_info=True)
             print(f"AES key setup command failed: {e}")
+            sys.exit(1)
 
     def setup_filters(self):
         logger.info("Setting up filters")
@@ -55,6 +56,7 @@ class EncryptionManager:
         except Exception as e:
             logger.error(f"Pull AES key command failed: {e}", exc_info=True)
             print(f"Pull AES key command failed: {e}")
+            sys.exit(1)
 
     def encrypt_files(self, filter_name: str):
         try:
@@ -74,6 +76,7 @@ class EncryptionManager:
         except Exception as e:
             logger.error(f"Encrypt files command failed: {e}", exc_info=True)
             print(f"Encrypt files command failed: {str(e)}")
+            sys.exit(1)
 
     def decrypt_files(self, filter_name: str):
         try:
@@ -93,6 +96,7 @@ class EncryptionManager:
         except Exception as e:
             logger.error(f"Decrypt files command failed: {e}", exc_info=True)
             print(f"Decrypt files command failed: {e}")
+            sys.exit(1)
 
     def encrypt_stdin(self, file_name):
         logging.info(f"Encrypting data from stdin for file: {file_name}")
@@ -165,6 +169,7 @@ class EncryptionManager:
         except Exception as e:
             logger.error(f"Rotate keys command failed: {e}", exc_info=True)
             print(f"Rotate keys command failed: {e}")
+            sys.exit(1)
 
     def clean_filter(self, filter_name: str):
         try:
@@ -183,6 +188,7 @@ class EncryptionManager:
         except Exception as e:
             logger.error(f"Clean filter command failed: {e}", exc_info=True)
             print(f"Clean filter command failed: {e}")
+            sys.exit(1)
 
     def status(self):
         try:
@@ -199,6 +205,7 @@ class EncryptionManager:
                     print("  No files found for this filter.")
         except Exception as e:
             print(f"Status command failed: {e}")
+            sys.exit(1)
 
     @staticmethod
     def show_project_version():
@@ -220,12 +227,16 @@ class EncryptionManager:
     @staticmethod
     def __init_filter(filter_name: str):
         # Check for existing Git filters
-        check_clean = subprocess.getoutput(
-            f"git config --get filter.{filter_name}.clean"
-        )
-        check_smudge = subprocess.getoutput(
-            f"git config --get filter.{filter_name}.smudge"
-        )
+        check_clean = subprocess.run(
+            ["git", "config", "--get", f"filter.{filter_name}.clean"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        check_smudge = subprocess.run(
+            ["git", "config", "--get", f"filter.{filter_name}.smudge"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
 
         logger.info("Setting up Git filters for '%s'", filter_name)
         if check_clean or check_smudge:

--- a/src/git_secret_protector/storage/aws_ssm_storage_manager.py
+++ b/src/git_secret_protector/storage/aws_ssm_storage_manager.py
@@ -1,13 +1,20 @@
 import json
 import logging
 
-import boto3
 from botocore.exceptions import NoCredentialsError, NoRegionError
 
 from git_secret_protector.error.storage_error import StorageError
-from git_secret_protector.storage.storage_manager_interface import StorageManagerInterface
+from git_secret_protector.storage.storage_manager_interface import (
+    StorageManagerInterface,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _boto3():
+    import boto3
+
+    return boto3
 
 
 def _get_short_region(region):
@@ -25,64 +32,76 @@ class AwsSsmStorageManager(StorageManagerInterface):
     def account_id(self):
         if self._account_id is None:
             try:
-                sts_client = boto3.client('sts')
-                self._account_id = sts_client.get_caller_identity().get('Account')
+                sts_client = _boto3().client("sts")
+                self._account_id = sts_client.get_caller_identity().get("Account")
             except NoCredentialsError:
-                raise StorageError("No AWS region configured. Please ensure your terminal is logged in to AWS.")
+                raise StorageError(
+                    "No AWS region configured. Please ensure your terminal is logged in to AWS."
+                )
         return self._account_id
 
     @property
     def region(self):
         if self._region is None:
             try:
-                full_region = boto3.session.Session().region_name
+                full_region = _boto3().session.Session().region_name
                 self._region = _get_short_region(region=full_region)
             except NoCredentialsError:
-                raise StorageError("No AWS region configured. Please ensure your terminal is logged in to AWS.")
+                raise StorageError(
+                    "No AWS region configured. Please ensure your terminal is logged in to AWS."
+                )
         return self._region
 
     @property
     def client(self):
         if self._client is None:
             try:
-                self._client = boto3.client('ssm')
+                self._client = _boto3().client("ssm")
             except NoRegionError:
-                raise StorageError("No AWS region configured. Please ensure your terminal is logged in to AWS.")
+                raise StorageError(
+                    "No AWS region configured. Please ensure your terminal is logged in to AWS."
+                )
         return self._client
 
     def store(self, name: str, value: str) -> None:
         try:
             self.client.put_parameter(
-                Name=name,
-                Value=json.dumps(value),
-                Type='SecureString',
-                Overwrite=True
+                Name=name, Value=json.dumps(value), Type="SecureString", Overwrite=True
             )
         except Exception as e:
-            raise StorageError(f"Failed to store parameter with [name={name}]: {str(e)}") from e
+            raise StorageError(
+                f"Failed to store parameter with [name={name}]: {str(e)}"
+            ) from e
 
     def retrieve(self, name: str) -> str:
         try:
             logger.info("Retrieving secret from AWS SSM with Name: %s", name)
             response = self.client.get_parameter(Name=name, WithDecryption=True)
-            return json.loads(response['Parameter']['Value'])
+            return json.loads(response["Parameter"]["Value"])
         except Exception as e:
             error_message = str(e)
             if "ParameterNotFound" in error_message:
                 if self.region in name:
                     return self._handle_legacy_parameter(parameter=name)
                 raise StorageError(f"Parameter not found [name={name}]") from e
-            raise StorageError(f"Failed to retrieve parameter [name={name}]: {error_message}") from e
+            raise StorageError(
+                f"Failed to retrieve parameter [name={name}]: {error_message}"
+            ) from e
 
     def _handle_legacy_parameter(self, parameter: str) -> str:
-        legacy_parameter = parameter.replace(f"/encryption/{self.account_id}/{self.region}/",
-                                             f"/encryption/{self.account_id}/")
+        legacy_parameter = parameter.replace(
+            f"/encryption/{self.account_id}/{self.region}/",
+            f"/encryption/{self.account_id}/",
+        )
         logger.warning(
-            f"Parameter '{parameter}' not found. Attempting to retrieve from legacy parameter '{legacy_parameter}'.")
+            f"Parameter '{parameter}' not found. Attempting to retrieve from legacy parameter '{legacy_parameter}'."
+        )
 
         result = self.retrieve(name=legacy_parameter)
 
-        logger.info(f"Legacy parameter '{legacy_parameter}' found. Copying to new parameter: '{parameter}'")
+        logger.info(
+            f"Legacy parameter '{legacy_parameter}' found. Copying to new parameter: '{parameter}'"
+        )
         self.store(parameter, result)
 
         return result
@@ -91,7 +110,9 @@ class AwsSsmStorageManager(StorageManagerInterface):
         try:
             self.client.delete_parameter(Name=name)
         except Exception as e:
-            raise StorageError(f"Failed to delete parameter with [name={name}]: {str(e)}") from e
+            raise StorageError(
+                f"Failed to delete parameter with [name={name}]: {str(e)}"
+            ) from e
 
     def exists(self, name: str) -> bool:
         try:
@@ -101,7 +122,9 @@ class AwsSsmStorageManager(StorageManagerInterface):
             error_message = str(e)
             if "ParameterNotFound" in error_message:
                 return False
-            raise StorageError(f"Failed to check if parameter exists [name={name}]: {error_message}") from e
+            raise StorageError(
+                f"Failed to check if parameter exists [name={name}]: {error_message}"
+            ) from e
 
     def parameter_name(self, module_name: str, filter_name: str):
         return f"/encryption/{self.account_id}/{self.region}/{module_name}/{filter_name}/key_iv"

--- a/src/git_secret_protector/storage/gcp_secret_storage_manager.py
+++ b/src/git_secret_protector/storage/gcp_secret_storage_manager.py
@@ -2,22 +2,43 @@ import json
 import logging
 import subprocess
 
-from google.api_core.exceptions import NotFound, AlreadyExists, GoogleAPIError
-from google.auth import default
-from google.cloud import secretmanager
-from google.cloud.secretmanager_v1 import Secret, SecretPayload
-
 from git_secret_protector.core.settings import get_settings
 from git_secret_protector.error.storage_error import StorageError
-from git_secret_protector.storage.storage_manager_interface import StorageManagerInterface
+from git_secret_protector.storage.storage_manager_interface import (
+    StorageManagerInterface,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _secretmanager():
+    from google.cloud import secretmanager
+
+    return secretmanager
+
+
+def _secret_types():
+    from google.cloud.secretmanager_v1 import Secret, SecretPayload
+
+    return Secret, SecretPayload
+
+
+def _default_credentials():
+    from google.auth import default
+
+    return default
+
+
+def _google_exceptions():
+    from google.api_core.exceptions import AlreadyExists, GoogleAPIError, NotFound
+
+    return AlreadyExists, GoogleAPIError, NotFound
 
 
 class GcpSecretStorageManager(StorageManagerInterface):
     def __init__(self):
         self.settings = get_settings()
-        self.client = secretmanager.SecretManagerServiceClient()
+        self.client = _secretmanager().SecretManagerServiceClient()
         self._project_id = None
 
     @property
@@ -29,70 +50,85 @@ class GcpSecretStorageManager(StorageManagerInterface):
     @staticmethod
     def _fetch_project_id() -> str:
         try:
-            logger.debug('Getting project ID from default credentials')
-            _, project_id = default()
+            logger.debug("Getting project ID from default credentials")
+            _, project_id = _default_credentials()()
             return project_id
         except Exception as e:
-            raise StorageError(f"Failed to retrieve project ID from the default credentials: {str(e)}") from e
+            raise StorageError(
+                f"Failed to retrieve project ID from the default credentials: {str(e)}"
+            ) from e
 
     def store(self, name: str, value: str) -> None:
         secret_id = f"projects/{self.project_id}/secrets/{name}"
+        AlreadyExists, GoogleAPIError, NotFound = _google_exceptions()
         try:
             # Check if the secret already exists, otherwise create it
             self.client.access_secret_version(name=f"{secret_id}/versions/latest")
         except NotFound:
             # Create the secret if it doesn't exist
             try:
+                Secret, SecretPayload = _secret_types()
                 self.client.create_secret(
                     parent=f"projects/{self.project_id}",
                     secret_id=name,
-                    secret=Secret(
-                        replication={"automatic": {}}
-                    )
+                    secret=Secret(replication={"automatic": {}}),
                 )
             except AlreadyExists:
                 raise ValueError(f"Secret with name [{name}] already exists.")
         except GoogleAPIError as e:
-            raise StorageError(f"Google API error while storing the secret: {str(e)}") from e
+            raise StorageError(
+                f"Google API error while storing the secret: {str(e)}"
+            ) from e
 
         # Add a new version with the updated secret value
         try:
+            _, SecretPayload = _secret_types()
             self.client.add_secret_version(
-                parent=secret_id,
-                payload=SecretPayload({"data": value.encode("UTF-8")})
+                parent=secret_id, payload=SecretPayload({"data": value.encode("UTF-8")})
             )
         except GoogleAPIError as e:
             raise StorageError(f"Failed to add secret version: {str(e)}") from e
 
     def retrieve(self, name: str) -> str:
         secret_id = f"projects/{self.project_id}/secrets/{name}/versions/latest"
+        _, GoogleAPIError, NotFound = _google_exceptions()
         try:
-            logger.info("Retrieving secret from GCP Secret Manager with ID: %s", secret_id)
+            logger.info(
+                "Retrieving secret from GCP Secret Manager with ID: %s", secret_id
+            )
             response = self.client.access_secret_version(name=secret_id)
             return response.payload.data.decode("UTF-8")
         except NotFound:
             raise ValueError(f"Secret [name={name}] not found.")
         except GoogleAPIError as e:
-            raise StorageError(f"Google API error while retrieving the secret: {str(e)}") from e
+            raise StorageError(
+                f"Google API error while retrieving the secret: {str(e)}"
+            ) from e
 
     def delete(self, name: str) -> None:
         secret_id = f"projects/{self.project_id}/secrets/{name}"
+        _, GoogleAPIError, NotFound = _google_exceptions()
         try:
             self.client.delete_secret(name=secret_id)
         except NotFound:
             raise ValueError(f"Secret [name={name}] not found.")
         except GoogleAPIError as e:
-            raise StorageError(f"Google API error while deleting the secret: {str(e)}") from e
+            raise StorageError(
+                f"Google API error while deleting the secret: {str(e)}"
+            ) from e
 
     def exists(self, name: str) -> bool:
         secret_id = f"projects/{self.project_id}/secrets/{name}"
+        _, GoogleAPIError, NotFound = _google_exceptions()
         try:
             self.client.access_secret_version(name=f"{secret_id}/versions/latest")
             return True
         except NotFound:
             return False
         except GoogleAPIError as e:
-            raise StorageError(f"Google API error while checking if the secret exists: {str(e)}") from e
+            raise StorageError(
+                f"Google API error while checking if the secret exists: {str(e)}"
+            ) from e
 
     def parameter_name(self, module_name: str, filter_name: str):
         return f"encryption_{module_name}_{filter_name}_key_iv"

--- a/src/git_secret_protector/storage/storage_manager_factory.py
+++ b/src/git_secret_protector/storage/storage_manager_factory.py
@@ -1,16 +1,24 @@
 from git_secret_protector.core.settings import StorageType
-from git_secret_protector.storage.aws_ssm_storage_manager import AwsSsmStorageManager
-from git_secret_protector.storage.gcp_secret_storage_manager import GcpSecretStorageManager
-from git_secret_protector.storage.storage_manager_interface import StorageManagerInterface
+from git_secret_protector.storage.storage_manager_interface import (
+    StorageManagerInterface,
+)
 
 
 class StorageManagerFactory:
 
     @staticmethod
-    def create(storage_type: str = 'aws_ssm') -> 'StorageManagerInterface':
+    def create(storage_type: str = "aws_ssm") -> "StorageManagerInterface":
         if storage_type == StorageType.AWS_SSM.value:
+            from git_secret_protector.storage.aws_ssm_storage_manager import (
+                AwsSsmStorageManager,
+            )
+
             return AwsSsmStorageManager()
         elif storage_type == StorageType.GCP_SECRET.value:
+            from git_secret_protector.storage.gcp_secret_storage_manager import (
+                GcpSecretStorageManager,
+            )
+
             return GcpSecretStorageManager()
         else:
             raise ValueError(f"Unknown storage type: {storage_type}")

--- a/tests/unit/test_aes_key_manager.py
+++ b/tests/unit/test_aes_key_manager.py
@@ -14,7 +14,7 @@ from git_secret_protector.crypto.aes_key_manager import AesKeyManager
 
 class TestAesKeyManager(unittest.TestCase):
 
-    @patch('git_secret_protector.crypto.aes_key_manager.get_settings')
+    @patch("git_secret_protector.crypto.aes_key_manager.get_settings")
     @patch("git_secret_protector.crypto.aes_key_manager.StorageManagerFactory.create")
     def setUp(self, mock_create, mock_get_settings):
         self.mock_settings = MagicMock()
@@ -32,26 +32,26 @@ class TestAesKeyManager(unittest.TestCase):
 
     @staticmethod
     def random_encoded_data():
-        aes_key = base64.b64encode(secrets.token_bytes(32)).decode('utf-8')
-        iv = base64.b64encode(secrets.token_bytes(16)).decode('utf-8')
-        return json.dumps({'aes_key': aes_key, 'iv': iv})
+        aes_key = base64.b64encode(secrets.token_bytes(32)).decode("utf-8")
+        iv = base64.b64encode(secrets.token_bytes(16)).decode("utf-8")
+        return json.dumps({"aes_key": aes_key, "iv": iv})
 
-    @patch('boto3.client')
-    @patch('boto3.session.Session')
+    @patch("boto3.client")
+    @patch("boto3.session.Session")
     def test_setup_aes_key_and_iv(self, mock_session, mock_boto_client):
         filter_name = secrets.token_hex(8)
         account_id = secrets.token_hex(8)
 
-        mock_boto_client.return_value.get_caller_identity.return_value = {'Account': account_id}
+        mock_boto_client.return_value.get_caller_identity.return_value = {
+            "Account": account_id
+        }
         mock_session.return_value.region_name = "us-west-2"
 
         # Configure the mock to raise a ClientError for get_parameter
-        mock_boto_client.return_value.get_parameter.side_effect = ClientError({
-            'Error': {
-                'Code': 'ParameterNotFound',
-                'Message': 'Parameter not found'
-            }
-        }, 'GetParameter')
+        mock_boto_client.return_value.get_parameter.side_effect = ClientError(
+            {"Error": {"Code": "ParameterNotFound", "Message": "Parameter not found"}},
+            "GetParameter",
+        )
 
         self.aes_key_manager.setup_aes_key_and_iv(filter_name)
 
@@ -59,13 +59,13 @@ class TestAesKeyManager(unittest.TestCase):
 
         mock_boto_client.return_value.put_parameter.assert_called_once()
         args, kwargs = mock_boto_client.return_value.put_parameter.call_args
-        self.assertEqual(kwargs['Name'], expected_parameter_name)
-        self.assertEqual('SecureString', kwargs['Type'])
-        data = json.loads(kwargs['Value'])
-        self.assertTrue('aes_key' in data and 'iv' in data)
+        self.assertEqual(kwargs["Name"], expected_parameter_name)
+        self.assertEqual("SecureString", kwargs["Type"])
+        data = json.loads(kwargs["Value"])
+        self.assertTrue("aes_key" in data and "iv" in data)
 
-    @patch('os.path.exists', return_value=True)
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    @patch("os.path.exists", return_value=True)
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
     def test_retrieve_key_and_iv_from_cache_hit(self, mock_open, _):
         json_data = self.random_encoded_data()
         filter_name = secrets.token_hex(8)
@@ -74,13 +74,12 @@ class TestAesKeyManager(unittest.TestCase):
         aes_key, iv = self.aes_key_manager.retrieve_key_and_iv(filter_name)
 
         data = json.loads(json_data)
-        self.assertEqual(aes_key, base64.b64decode(data['aes_key']))
-        self.assertEqual(iv, base64.b64decode(data['iv']))
+        self.assertEqual(aes_key, base64.b64decode(data["aes_key"]))
+        self.assertEqual(iv, base64.b64decode(data["iv"]))
 
-    @patch('os.path.exists', return_value=False)
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    @patch("os.path.exists", return_value=False)
     @patch("git_secret_protector.crypto.aes_key_manager.StorageManagerFactory.create")
-    def test_retrieve_key_and_iv_from_cache_miss(self, mock_create, mock_open, _):
+    def test_retrieve_key_and_iv_from_cache_miss(self, mock_create, _):
         mock_create.return_value = self.mock_storage_manager
         self.mock_storage_manager.parameter_name.return_value = secrets.token_hex(8)
 
@@ -90,27 +89,45 @@ class TestAesKeyManager(unittest.TestCase):
 
         aes_key, iv = self.aes_key_manager.retrieve_key_and_iv(filter_name)
 
-        mock_open.assert_called_once_with(self.aes_key_manager._cache_path(filter_name=filter_name), 'w')
-        handle = mock_open()
-        handle.write.assert_called_once_with(json_data)
+        self.mock_storage_manager.retrieve.assert_called_once()
+        cache_path = self.aes_key_manager._cache_path(filter_name=filter_name)
+        with open(cache_path, "r") as cache_file:
+            self.assertEqual(cache_file.read(), json_data)
+        self.assertEqual(oct(os.stat(cache_path).st_mode & 0o777), "0o600")
 
         data = json.loads(json_data)
-        self.assertEqual(aes_key, base64.b64decode(data['aes_key']))
-        self.assertEqual(iv, base64.b64decode(data['iv']))
+        self.assertEqual(aes_key, base64.b64decode(data["aes_key"]))
+        self.assertEqual(iv, base64.b64decode(data["iv"]))
 
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
-    def test_cache_key_iv_locally(self, mock_open):
+    def test_cache_key_iv_locally(self):
         json_data = self.random_encoded_data()
         filter_name = secrets.token_hex(8)
 
         self.aes_key_manager.cache_key_iv_locally(filter_name, json_data)
 
-        mock_open.assert_called_once_with(self.aes_key_manager._cache_path(filter_name=filter_name), 'w')
-        handle = mock_open()
-        handle.write.assert_called_once_with(json_data)
+        cache_path = self.aes_key_manager._cache_path(filter_name=filter_name)
+        with open(cache_path, "r") as cache_file:
+            self.assertEqual(cache_file.read(), json_data)
+        self.assertEqual(oct(os.stat(cache_path).st_mode & 0o777), "0o600")
 
-    @patch('os.path.exists', return_value=True)
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    def test_cache_key_iv_locally_tightens_existing_file_permissions(self):
+        json_data = self.random_encoded_data()
+        filter_name = secrets.token_hex(8)
+        cache_path = self.aes_key_manager._cache_path(filter_name=filter_name)
+
+        existing_fd = os.open(cache_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        with os.fdopen(existing_fd, "w") as cache_file:
+            cache_file.write("stale-data")
+        os.chmod(cache_path, 0o644)
+
+        self.aes_key_manager.cache_key_iv_locally(filter_name, json_data)
+
+        with open(cache_path, "r") as cache_file:
+            self.assertEqual(cache_file.read(), json_data)
+        self.assertEqual(oct(os.stat(cache_path).st_mode & 0o777), "0o600")
+
+    @patch("os.path.exists", return_value=True)
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
     def test_load_key_iv_from_cache(self, mock_open, mock_exists):
         json_data = self.random_encoded_data()
         filter_name = secrets.token_hex(8)
@@ -118,20 +135,28 @@ class TestAesKeyManager(unittest.TestCase):
 
         data = self.aes_key_manager.load_key_iv_from_cache(filter_name)
 
-        mock_exists.assert_called_once_with(os.path.join(self.mock_temp_dir.name, f'{filter_name}_key_iv.json'))
-        self.assertEqual(data, json.loads(json_data), "Expected data to match JSON content")
+        mock_exists.assert_called_once_with(
+            os.path.join(self.mock_temp_dir.name, f"{filter_name}_key_iv.json")
+        )
+        self.assertEqual(
+            data, json.loads(json_data), "Expected data to match JSON content"
+        )
 
-    @patch('os.path.exists', return_value=False)
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    @patch("os.path.exists", return_value=False)
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
     def test_load_key_iv_from_cache_not_found(self, mock_open, mock_exists):
         filter_name = secrets.token_hex(8)
 
         result = self.aes_key_manager.load_key_iv_from_cache(filter_name)
 
-        mock_exists.assert_called_once_with(os.path.join(self.mock_settings.cache_dir, f'{filter_name}_key_iv.json'))
+        mock_exists.assert_called_once_with(
+            os.path.join(self.mock_settings.cache_dir, f"{filter_name}_key_iv.json")
+        )
         mock_open.assert_not_called()  # Ensures open was not called since file does not exist
-        self.assertIsNone(result, "Expected result to be None when cache file does not exist")
+        self.assertIsNone(
+            result, "Expected result to be None when cache file does not exist"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -1,6 +1,9 @@
 import base64
 import io
+import json
+import os
 import secrets
+import tempfile
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -10,6 +13,8 @@ from Crypto.Util.Padding import pad
 
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
 from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
+from git_secret_protector.crypto.aes_key_manager import AesKeyManager
+from git_secret_protector.main import show_project_version
 from git_secret_protector.services.encryption_manager import EncryptionManager
 from tests.utils.random_utils import generate_random_string
 
@@ -148,23 +153,83 @@ class TestEncryptionManagerService(unittest.TestCase):
 
         self.assertEqual(stdout_buffer.getvalue(), b"ciphertext")
 
+    def test_pull_aes_key_exits_non_zero_when_retrieve_raises(self):
+        self.key_manager.retrieve_key_and_iv.side_effect = RuntimeError("boom")
+
+        with self.assertRaises(SystemExit) as context:
+            self.manager.pull_aes_key("secret")
+
+        self.assertEqual(context.exception.code, 1)
+
+    def test_decrypt_stdin_does_not_exit_when_decryption_raises(self):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+        encrypted_data = b"ciphertext"
+        stdout_buffer = io.BytesIO()
+        stdin = SimpleNamespace(buffer=io.BytesIO(encrypted_data))
+        stdout = SimpleNamespace(buffer=stdout_buffer)
+
+        with patch.object(
+            self.manager,
+            "_EncryptionManager__get_encryption_handler",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+                self.manager.decrypt_stdin("secrets.env")
+
+        self.assertEqual(stdout_buffer.getvalue(), encrypted_data)
+
     @patch("git_secret_protector.services.encryption_manager.subprocess.run")
-    @patch("git_secret_protector.services.encryption_manager.subprocess.getoutput")
-    def test_setup_filters_sets_required_for_existing_filter(
-        self, mock_getoutput, mock_run
-    ):
+    def test_setup_filters_sets_required_for_existing_filter(self, mock_run):
         self.git_attributes_parser.get_filter_names.return_value = ["secret"]
-        mock_getoutput.side_effect = [
-            "git-secret-protector encrypt %f",
-            "git-secret-protector decrypt %f",
+        mock_run.side_effect = [
+            MagicMock(stdout="git-secret-protector encrypt %f\n"),
+            MagicMock(stdout="git-secret-protector decrypt %f\n"),
+            MagicMock(),
         ]
 
         self.manager.setup_filters()
 
-        mock_run.assert_called_once_with(
+        self.assertEqual(
+            mock_run.call_args_list[0].args[0],
+            ["git", "config", "--get", "filter.secret.clean"],
+        )
+        self.assertEqual(
+            mock_run.call_args_list[1].args[0],
+            ["git", "config", "--get", "filter.secret.smudge"],
+        )
+        mock_run.assert_called_with(
             ["git", "config", "filter.secret.required", "true"],
             check=True,
         )
+
+    def test_cache_key_iv_locally_writes_owner_only_mode(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch(
+                "git_secret_protector.crypto.aes_key_manager.get_settings"
+            ) as mock_get_settings:
+                mock_settings = MagicMock()
+                mock_settings.cache_dir = temp_dir
+                mock_settings.module_name = "git-secret-protector"
+                mock_get_settings.return_value = mock_settings
+
+                manager = AesKeyManager()
+                data = json.dumps({"aes_key": "a", "iv": "b"})
+
+                manager.cache_key_iv_locally("secret", data)
+
+                cache_path = os.path.join(temp_dir, "secret_key_iv.json")
+                self.assertEqual(oct(os.stat(cache_path).st_mode & 0o777), "0o600")
+
+
+class TestMain(unittest.TestCase):
+    @patch("git_secret_protector.main.EncryptionManager.show_project_version")
+    @patch("git_secret_protector.main.manager", None)
+    def test_show_project_version_does_not_require_manager(
+        self, mock_show_project_version
+    ):
+        show_project_version(None)
+
+        mock_show_project_version.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_import_check(code: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    pythonpath = str(ROOT / "src")
+    env["PYTHONPATH"] = (
+        f"{pythonpath}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else pythonpath
+    )
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_importing_factory_does_not_import_cloud_sdks():
+    result = _run_import_check(
+        "import git_secret_protector.storage.storage_manager_factory as f; "
+        "import sys; "
+        "assert 'boto3' not in sys.modules; "
+        "assert not any(m == 'google.cloud' or m.startswith('google.cloud.') for m in sys.modules)"
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_importing_aws_manager_module_does_not_import_boto3():
+    result = _run_import_check(
+        "import git_secret_protector.storage.aws_ssm_storage_manager; "
+        "import sys; "
+        "assert 'boto3' not in sys.modules"
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_importing_gcp_manager_module_does_not_import_google_sdk():
+    result = _run_import_check(
+        "import git_secret_protector.storage.gcp_secret_storage_manager; "
+        "import sys; "
+        "assert not any(m == 'google.cloud' or m.startswith('google.cloud.') for m in sys.modules)"
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

### Why
Follow-up hardening to the fail-closed clean filter. The CLI swallowed errors and exited 0, ran a shell for git-config reads (injectable via filter names), wrote the AES key cache world-readable, and imported both cloud SDKs on every per-file filter invocation.

### What
Two coherent slices (no crypto/format/key changes):

- **Security**
  - Management/bulk handlers exit **non-zero** on failure (CI/scripts can detect errors). Smudge stays fail-safe (exit 0) so a missing key never blocks checkout.
  - `__init_filter` reads git config via **list-form `subprocess.run`** (no shell) — closes a shell-injection vector via attacker-controlled filter names from `.gitattributes`.
  - AES key cache written **0600**, mode locked on the fd *before* the write (`os.fchmod`) so there's no world-readable window even for a pre-existing 0644 cache.
  - Init appends `.git_secret_protector/` to the repo **`.gitignore`** so the plaintext-key cache can't be committed by accident.
  - Injector built **lazily** in `main()` — `version`/`--help` work outside a git repo (fixes the eager module-load crash).
- **Performance**
  - **Lazy-import boto3 / google-cloud-secret-manager** — the cached clean/smudge path (one process per file) imports neither SDK.

```mermaid
flowchart LR
  A[git checkout / add — per file] --> B[clean/smudge process]
  B --> C[read local key cache]
  C -. before .-> D[import boto3 + google every time ~0.8s]
  C -. after .-> E[no SDK import]
```

### Solution
Control-flow + import-locality only. Cache stays per-repo (no path move → no cross-repo collision). Backward compatible: existing keys, encrypted files, and caches keep working; existing 0644 caches are tightened to 0600 on next write.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- `poetry run pytest tests/unit` — new/updated tests pass (exit-code behavior, smudge stays exit 0, no-shell git config, cache 0600 incl. 0644→0600 upgrade, lazy-import via subprocess assertions). The 4 `test_git_attributes_parser` failures are pre-existing and environment-specific (green in CI).
- Functional: `version`/`--help` succeed outside a git repo; `setup-filters` appends `.git_secret_protector/` to `.gitignore`; importing the key-manager chain pulls in neither `boto3` nor `google.cloud`; CLI startup ~0.08s vs ~0.86s.

## Related Issues
Follow-up to the fail-closed clean filter fix (#80). Next: authenticated/deterministic encryption (git-crypt-style CTR+HMAC) + versioned headers.