### PR TITLE
chore: gitignore Python artifacts, tool runtime, and agent tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,22 @@
 /dist/
 /.idea/
 
+# Python build/test artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Tool runtime (per-repo cache, logs, config)
+/.git_secret_protector/
+
+# Agent tooling (local, machine-specific)
+/.agent/
+/.codex/
+
 # Personal, machine-local Claude guidance (never committed)
 CLAUDE.local.md


### PR DESCRIPTION
Ignore `__pycache__`/test caches, the per-repo `.git_secret_protector/` runtime dir, and local agent tooling (`.agent/`, `.codex/`) so they stop showing as untracked noise. Config-only.