### PR TITLE
fix: harden repo base-dir detection (marker-first + env override)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The tool is a CLI that integrates with git's smudge/clean filter mechanism to tr
 
 **Configuration** (`core/settings.py`):
 - `Settings` is a singleton loaded at import time via `get_settings()`.
-- It walks up the directory tree looking for `.git/` to find the repo root — raises `FileNotFoundError` if not in a git repo.
+- `_find_base_dir()` resolves the repo root by precedence: `SECRET_PROTECTOR_BASE_DIR` env override (must be an existing dir) → walk up for an existing `.git_secret_protector/` marker → walk up for the nearest `.git` (bootstrap) → else raise `FileNotFoundError`. Marker-first is deliberate: in nested repos/submodules a bare `.git` walk would resolve to the *inner* repo and silently run on default config from the wrong SSM namespace. `git rev-parse` is intentionally not used (it returns the innermost toplevel — the same bug).
 - `storage_type` in `config.ini` controls the backend: `AWS_SSM` (default) or `GCP_SECRET`.
 
 **Dependency injection** (`context/module.py`):

--- a/src/git_secret_protector/core/settings.py
+++ b/src/git_secret_protector/core/settings.py
@@ -5,62 +5,105 @@ from enum import Enum
 
 
 class StorageType(Enum):
-    AWS_SSM = 'AWS_SSM'
-    GCP_SECRET = 'GCP_SECRET'
+    AWS_SSM = "AWS_SSM"
+    GCP_SECRET = "GCP_SECRET"
 
 
 @dataclass
 class Settings:
     BASE_DIR_LOOKUP_FOLDER = ".git"
+    MODULE_MARKER = ".git_secret_protector"
+    BASE_DIR_ENV_VAR = "SECRET_PROTECTOR_BASE_DIR"
 
-    _instance: 'Settings' = field(default=None, init=False, repr=False, compare=False)
-    module_folder: str = '.git_secret_protector'
+    _instance: "Settings" = field(default=None, init=False, repr=False, compare=False)
+    module_folder: str = ".git_secret_protector"
     base_dir: str = field(init=False)
     module_dir: str = field(init=False)
     config_file: str = field(init=False)
     cache_dir: str = field(init=False)
     log_dir: str = field(init=False)
-    module_name: str = 'git-secret-protector'
+    module_name: str = "git-secret-protector"
     log_file: str = field(init=False)
-    log_level: str = 'INFO'
+    log_level: str = "INFO"
     log_max_size: int = 1048576  # 10MB
     log_backup_count: int = 3
-    magic_header: str = 'ENCRYPTED'
+    magic_header: str = "ENCRYPTED"
     storage_type: StorageType = StorageType.AWS_SSM
     config: configparser.ConfigParser = field(init=False)
 
     def __post_init__(self):
         self.base_dir = self._find_base_dir()
         self.module_dir = os.path.join(self.base_dir, self.module_folder)
-        self.config_file = os.path.join(self.module_dir, 'config.ini')
-        self.cache_dir = os.path.join(self.module_dir, 'cache')
-        self.log_dir = os.path.join(self.module_dir, 'logs')
-        self.log_file = os.path.join(self.log_dir, 'git_secret_protector.log')
+        self.config_file = os.path.join(self.module_dir, "config.ini")
+        self.cache_dir = os.path.join(self.module_dir, "cache")
+        self.log_dir = os.path.join(self.module_dir, "logs")
+        self.log_file = os.path.join(self.log_dir, "git_secret_protector.log")
         self.config = configparser.ConfigParser()
         self._load_config()
 
     @staticmethod
-    def _find_base_dir():
+    def _walk_up(name, require_dir=False):
         current_dir = os.getcwd()
-        while current_dir != os.path.dirname(current_dir):  # Traverse up to the root directory
-            possible_dir = os.path.join(current_dir, Settings.BASE_DIR_LOOKUP_FOLDER)
-            if os.path.exists(possible_dir):
+        while True:
+            possible_path = os.path.join(current_dir, name)
+            if os.path.exists(possible_path) and (
+                not require_dir or os.path.isdir(possible_path)
+            ):
                 return current_dir
-            current_dir = os.path.dirname(current_dir)
+            parent_dir = os.path.dirname(current_dir)
+            if parent_dir == current_dir:
+                return None
+            current_dir = parent_dir
+
+    @staticmethod
+    def _find_base_dir():
+        base_dir_override = os.environ.get(Settings.BASE_DIR_ENV_VAR)
+        if base_dir_override:
+            if os.path.isdir(base_dir_override):
+                return base_dir_override
+            raise FileNotFoundError(
+                f"{Settings.BASE_DIR_ENV_VAR} points to a missing directory: {base_dir_override}"
+            )
+
+        marker_dir = Settings._walk_up(Settings.MODULE_MARKER, require_dir=True)
+        if marker_dir:
+            return marker_dir
+
+        bootstrap_repo_dir = Settings._walk_up(Settings.BASE_DIR_LOOKUP_FOLDER)
+        if bootstrap_repo_dir:
+            return bootstrap_repo_dir
+
         raise FileNotFoundError(
-            "The git-secret-protector module folder was not found in any ascendant directories. Please ensure the module is set up correctly.")
+            "git-secret-protector must be run inside a git repository, but no .git directory "
+            "was found in the current directory or any parent. Set "
+            "SECRET_PROTECTOR_BASE_DIR to override."
+        )
 
     def _load_config(self):
         if os.path.exists(self.config_file):
             self.config.read(self.config_file)
-            self.module_name = self.config.get('DEFAULT', 'module_name', fallback=self.module_name)
-            self.log_file = self.config.get('DEFAULT', 'log_file', fallback=self.log_file)
-            self.log_level = self.config.get('DEFAULT', 'log_level', fallback=self.log_level)
-            self.log_max_size = self.config.getint('DEFAULT', 'log_max_size', fallback=self.log_max_size)
-            self.log_backup_count = self.config.getint('DEFAULT', 'log_backup_count', fallback=self.log_backup_count)
-            self.magic_header = self.config.get('DEFAULT', 'magic_header', fallback=self.magic_header)
+            self.module_name = self.config.get(
+                "DEFAULT", "module_name", fallback=self.module_name
+            )
+            self.log_file = self.config.get(
+                "DEFAULT", "log_file", fallback=self.log_file
+            )
+            self.log_level = self.config.get(
+                "DEFAULT", "log_level", fallback=self.log_level
+            )
+            self.log_max_size = self.config.getint(
+                "DEFAULT", "log_max_size", fallback=self.log_max_size
+            )
+            self.log_backup_count = self.config.getint(
+                "DEFAULT", "log_backup_count", fallback=self.log_backup_count
+            )
+            self.magic_header = self.config.get(
+                "DEFAULT", "magic_header", fallback=self.magic_header
+            )
 
-            storage_type_str = self.config.get('DEFAULT', 'storage_type', fallback=self.storage_type.value)
+            storage_type_str = self.config.get(
+                "DEFAULT", "storage_type", fallback=self.storage_type.value
+            )
             if storage_type_str in [member.value for member in StorageType]:
                 self.storage_type = StorageType(storage_type_str)
             else:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,104 @@
+import os
+
+import pytest
+
+from git_secret_protector.core.settings import Settings
+
+
+def test_find_base_dir_prefers_outer_marker_for_nested_repo(tmp_path, monkeypatch):
+    monkeypatch.delenv("SECRET_PROTECTOR_BASE_DIR", raising=False)
+    outer_dir = tmp_path / "outer"
+    inner_dir = outer_dir / "inner"
+    (outer_dir / ".git_secret_protector").mkdir(parents=True)
+    (outer_dir / ".git").mkdir()
+    (inner_dir / ".git").mkdir(parents=True)
+
+    monkeypatch.chdir(inner_dir)
+
+    assert os.path.realpath(Settings._find_base_dir()) == os.path.realpath(
+        str(outer_dir)
+    )
+
+
+def test_find_base_dir_prefers_nearest_marker_when_both_initialized(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("SECRET_PROTECTOR_BASE_DIR", raising=False)
+    outer_dir = tmp_path / "outer"
+    inner_dir = outer_dir / "inner"
+    (outer_dir / ".git_secret_protector").mkdir(parents=True)
+    (outer_dir / ".git").mkdir()
+    (inner_dir / ".git_secret_protector").mkdir(parents=True)
+    (inner_dir / ".git").mkdir()
+
+    monkeypatch.chdir(inner_dir)
+
+    assert os.path.realpath(Settings._find_base_dir()) == os.path.realpath(
+        str(inner_dir)
+    )
+
+
+def test_find_base_dir_env_override_takes_precedence(tmp_path, monkeypatch):
+    monkeypatch.delenv("SECRET_PROTECTOR_BASE_DIR", raising=False)
+    override_dir = tmp_path / "override"
+    repo_dir = tmp_path / "repo"
+    nested_dir = repo_dir / "nested"
+    override_dir.mkdir()
+    (repo_dir / ".git_secret_protector").mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+    nested_dir.mkdir()
+    monkeypatch.setenv("SECRET_PROTECTOR_BASE_DIR", str(override_dir))
+    monkeypatch.chdir(nested_dir)
+
+    assert os.path.realpath(Settings._find_base_dir()) == os.path.realpath(
+        str(override_dir)
+    )
+
+
+def test_find_base_dir_rejects_invalid_env_override(tmp_path, monkeypatch):
+    monkeypatch.delenv("SECRET_PROTECTOR_BASE_DIR", raising=False)
+    missing_dir = tmp_path / "missing"
+    monkeypatch.setenv("SECRET_PROTECTOR_BASE_DIR", str(missing_dir))
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        Settings._find_base_dir()
+
+    assert "SECRET_PROTECTOR_BASE_DIR" in str(exc_info.value)
+    assert str(missing_dir) in str(exc_info.value)
+
+
+def test_find_base_dir_bootstraps_from_git_dir_without_marker(tmp_path, monkeypatch):
+    monkeypatch.delenv("SECRET_PROTECTOR_BASE_DIR", raising=False)
+    repo_dir = tmp_path / "repo"
+    nested_dir = repo_dir / "nested"
+    (repo_dir / ".git").mkdir(parents=True)
+    nested_dir.mkdir()
+
+    monkeypatch.chdir(nested_dir)
+
+    assert os.path.realpath(Settings._find_base_dir()) == os.path.realpath(
+        str(repo_dir)
+    )
+
+
+def test_find_base_dir_supports_git_file_for_worktrees(tmp_path, monkeypatch):
+    monkeypatch.delenv("SECRET_PROTECTOR_BASE_DIR", raising=False)
+    repo_dir = tmp_path / "repo"
+    nested_dir = repo_dir / "nested"
+    repo_dir.mkdir()
+    (repo_dir / ".git").write_text("gitdir: /tmp/worktree\n")
+    nested_dir.mkdir()
+
+    monkeypatch.chdir(nested_dir)
+
+    assert os.path.realpath(Settings._find_base_dir()) == os.path.realpath(
+        str(repo_dir)
+    )
+
+
+def test_find_base_dir_raises_when_not_in_repo(tmp_path, monkeypatch):
+    monkeypatch.delenv("SECRET_PROTECTOR_BASE_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="git repository"):
+        Settings._find_base_dir()


### PR DESCRIPTION
## Summary

### Why
`Settings._find_base_dir()` anchored only on `.git`. In a nested repo or submodule it resolved to the **inner** repo, so when `.git_secret_protector/config.ini` lived at an outer repo the config silently failed to load and the tool ran on **default config** — fetching keys from the wrong SSM namespace with no error. Silent misconfiguration is a security bug for an encryption tool.

### What
New resolution precedence in `_find_base_dir()`:

```mermaid
flowchart TD
    A[SECRET_PROTECTOR_BASE_DIR set?] -->|yes, exists| R1[use it]
    A -->|yes, missing| E1[raise: clear error]
    A -->|no| B[walk up for .git_secret_protector/ marker]
    B -->|found| R2[use marker dir — fixes nesting]
    B -->|none| C[walk up for nearest .git]
    C -->|found| R3[use repo root — bootstrap]
    C -->|none| E2[raise: not inside a git repository]
```

- Marker-first walk eliminates the inner-repo divergence for any initialized repo.
- `SECRET_PROTECTOR_BASE_DIR` env override as an escape hatch (worktrees/monorepos/odd CI checkouts).
- `.git` walk uses `os.path.exists`, so a `.git` **file** (worktrees/submodules) still resolves.
- Corrected not-in-repo error message.

### Solution
- `git rev-parse --show-toplevel` is intentionally **not** used — it returns the innermost toplevel, i.e. the same bug; and it would add a subprocess surface against the no-shell hardening.
- Fail-loud-on-missing-config was considered and **rejected**: `.git_secret_protector/` is gitignored, so config is local and regenerated as defaults by design, and team onboarding runs `pull-aes-key` before `setup-filters`. A hard fail there would break documented onboarding without a security gain — the marker-first walk already closes the dangerous case.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- New `tests/unit/test_settings.py` (7 cases): outer-marker-in-nested-repo, nearest-marker-when-both, env-override precedence, invalid env override, bootstrap-from-.git, `.git`-file worktree, not-in-repo message. All pass.
- `poetry run pytest tests/unit` — green except the 4 pre-existing `test_git_attributes_parser` failures (known local-env-only; green in CI).
- Smoke-tested the CLI: base-dir resolves correctly here, and the env override fails fast with the new message.

Note: black normalized pre-existing single-quoted strings in `settings.py` (the file was not previously black-clean), so that file's diff is larger than the logic change.