### PR TITLE
fix: clean CLI error outside git repo + parser test isolation

### DIFF
--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -1,5 +1,6 @@
 import argparse
 import configparser
+import sys
 from pathlib import Path
 
 from git_secret_protector.context.module import GitSecretProtectorModule
@@ -173,12 +174,16 @@ def main():
 
     args = parser.parse_args()
     if hasattr(args, "func"):
-        if args.func is not show_project_version:
-            init_module_folder()
-            configure_logging()
-            global manager
-            manager = GitSecretProtectorModule.get_injector().get(EncryptionManager)
-        args.func(args)
+        try:
+            if args.func is not show_project_version:
+                init_module_folder()
+                configure_logging()
+                global manager
+                manager = GitSecretProtectorModule.get_injector().get(EncryptionManager)
+            args.func(args)
+        except FileNotFoundError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
     else:
         parser.print_help()
 

--- a/tests/unit/test_git_attributes_parser.py
+++ b/tests/unit/test_git_attributes_parser.py
@@ -1,7 +1,10 @@
+import builtins
 import unittest
 from unittest.mock import patch, mock_open
 
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
+
+_REAL_OPEN = builtins.open
 
 
 class TestGitAttributesParser(unittest.TestCase):
@@ -14,52 +17,65 @@ config/*.conf filter=configfilter
 *.data filter=datafilter
 database/*.sql filter=sqlfilter
         """
-        self.m_open = mock_open(read_data=self.attributes_content)
+
+        def _scoped_open(file, *args, **kwargs):
+            if str(file).endswith(".gitattributes"):
+                return mock_open(read_data=self.attributes_content)(
+                    file, *args, **kwargs
+                )
+            return _REAL_OPEN(file, *args, **kwargs)
+
+        self.open_patch = lambda: patch("builtins.open", side_effect=_scoped_open)
 
     def test_parse_patterns(self):
-        with patch('builtins.open', self.m_open):
+        with self.open_patch():
             parser = GitAttributesParser()
             patterns = parser.patterns
 
             # Assertions to ensure all filters are parsed correctly
-            self.assertIn('secretfilter', patterns)
-            self.assertIn('configfilter', patterns)
-            self.assertIn('datafilter', patterns)
-            self.assertIn('sqlfilter', patterns)
-            self.assertEqual(patterns['secretfilter'], ['*.secret'])
-            self.assertEqual(patterns['configfilter'], ['config/*.conf'])
-            self.assertEqual(patterns['datafilter'], ['*.data'])
-            self.assertEqual(patterns['sqlfilter'], ['database/*.sql'])
+            self.assertIn("secretfilter", patterns)
+            self.assertIn("configfilter", patterns)
+            self.assertIn("datafilter", patterns)
+            self.assertIn("sqlfilter", patterns)
+            self.assertEqual(patterns["secretfilter"], ["*.secret"])
+            self.assertEqual(patterns["configfilter"], ["config/*.conf"])
+            self.assertEqual(patterns["datafilter"], ["*.data"])
+            self.assertEqual(patterns["sqlfilter"], ["database/*.sql"])
 
-    @patch('glob.glob', side_effect=lambda pattern, recursive: ['/fake/repo/example.data'])
+    @patch(
+        "glob.glob", side_effect=lambda pattern, recursive: ["/fake/repo/example.data"]
+    )
     def test_get_files_for_filter(self, mock_glob):
-        with patch('builtins.open', self.m_open):
+        with self.open_patch():
             parser = GitAttributesParser()
-            files = parser.get_files_for_filter('datafilter')
+            files = parser.get_files_for_filter("datafilter")
 
             # Check that the files are correctly identified for the datafilter
-            self.assertEqual(files, ['/fake/repo/example.data'])
+            self.assertEqual(files, ["/fake/repo/example.data"])
             mock_glob.assert_called_once()
 
     def test_get_filter_name_for_file(self):
-        with patch('builtins.open', self.m_open):
+        with self.open_patch():
             parser = GitAttributesParser()
-            filter_name = parser.get_filter_name_for_file('/fake/repo/config/app.conf', '/fake/repo')
+            filter_name = parser.get_filter_name_for_file(
+                "/fake/repo/config/app.conf", "/fake/repo"
+            )
 
             # Assert that the correct filter name is returned based on pattern
-            self.assertEqual(filter_name, 'configfilter')
+            self.assertEqual(filter_name, "configfilter")
 
     def test_get_secret_files(self):
-        with patch('builtins.open', self.m_open), \
-                patch('git_secret_protector.core.git_attributes_parser.GitAttributesParser._find_files_matching_patterns',
-                      return_value=['/fake/repo/config/app.conf', '/fake/repo/database/test.sql']):
+        with self.open_patch(), patch(
+            "git_secret_protector.core.git_attributes_parser.GitAttributesParser._find_files_matching_patterns",
+            return_value=["/fake/repo/config/app.conf", "/fake/repo/database/test.sql"],
+        ):
             parser = GitAttributesParser()
             secret_files = parser.get_secret_files()
 
             # Assert that all secret files from all filters are returned
-            self.assertIn('/fake/repo/config/app.conf', secret_files)
-            self.assertIn('/fake/repo/database/test.sql', secret_files)
+            self.assertIn("/fake/repo/config/app.conf", secret_files)
+            self.assertIn("/fake/repo/database/test.sql", secret_files)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_main(args, tmp_path):
+    env = os.environ.copy()
+    env.pop("SECRET_PROTECTOR_BASE_DIR", None)
+
+    pythonpath = str(ROOT / "src")
+    env["PYTHONPATH"] = (
+        f"{pythonpath}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else pythonpath
+    )
+
+    return subprocess.run(
+        [sys.executable, "-m", "git_secret_protector.main", *args],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_status_outside_git_repo_exits_cleanly(tmp_path):
+    result = _run_main(["status"], tmp_path)
+
+    assert result.returncode == 1
+    assert "git repository" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_help_outside_git_repo_still_works(tmp_path):
+    result = _run_main(["--help"], tmp_path)
+
+    assert result.returncode == 0
+    assert "usage" in result.stdout


### PR DESCRIPTION
## Summary

Two small, independent fixes.

### Why
1. Running a real command (e.g. `status`) **outside a git repository** dumped a full Python traceback with a non-1 exit — confusing for end users. (`--help`/`version` already worked.)
2. The `test_git_attributes_parser` tests failed when run in isolation (cold `Settings` singleton): they patched `builtins.open` globally, so `configparser` read `config.ini` through the `.gitattributes` mock and raised `MissingSectionHeaderError`. They passed in CI only because an earlier test happened to warm the singleton.

### What
- **`main.py`**: wrap command dispatch in `try/except FileNotFoundError` → print a one-line `Error: ...` to **stderr** and `exit 1`. No traceback. Adds subprocess-based CLI tests (`status` outside a repo → exit 1 + clean message; `--help` → exit 0).
- **`test_git_attributes_parser.py`**: path-scope the `open` patch so only `.gitattributes` is mocked; `config.ini` uses the real `open`. Tests now pass in isolation.

### Result
Full unit suite is green (**42 passed, 0 failed**) — the 4 long-standing local-only parser failures are resolved.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test (non-breaking change related to testing)

## Test Plan
- `poetry run pytest tests/unit/test_git_attributes_parser.py -q` — passes in isolation (the fix).
- `poetry run pytest tests/unit/test_main_cli.py -q` — new CLI behavior.
- `poetry run pytest tests/unit -q` — 42 passed, 0 failed.