### PR TITLE
chore: drop legacy SSM parameter-path fallback (#1060)

### DIFF
--- a/src/git_secret_protector/storage/aws_ssm_storage_manager.py
+++ b/src/git_secret_protector/storage/aws_ssm_storage_manager.py
@@ -81,30 +81,10 @@ class AwsSsmStorageManager(StorageManagerInterface):
         except Exception as e:
             error_message = str(e)
             if "ParameterNotFound" in error_message:
-                if self.region in name:
-                    return self._handle_legacy_parameter(parameter=name)
                 raise StorageError(f"Parameter not found [name={name}]") from e
             raise StorageError(
                 f"Failed to retrieve parameter [name={name}]: {error_message}"
             ) from e
-
-    def _handle_legacy_parameter(self, parameter: str) -> str:
-        legacy_parameter = parameter.replace(
-            f"/encryption/{self.account_id}/{self.region}/",
-            f"/encryption/{self.account_id}/",
-        )
-        logger.warning(
-            f"Parameter '{parameter}' not found. Attempting to retrieve from legacy parameter '{legacy_parameter}'."
-        )
-
-        result = self.retrieve(name=legacy_parameter)
-
-        logger.info(
-            f"Legacy parameter '{legacy_parameter}' found. Copying to new parameter: '{parameter}'"
-        )
-        self.store(parameter, result)
-
-        return result
 
     def delete(self, name: str) -> None:
         try:

--- a/tests/unit/test_aws_ssm_storage_manager.py
+++ b/tests/unit/test_aws_ssm_storage_manager.py
@@ -1,0 +1,53 @@
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from git_secret_protector.error.storage_error import StorageError
+from git_secret_protector.storage.aws_ssm_storage_manager import AwsSsmStorageManager
+
+
+class TestAwsSsmStorageManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = AwsSsmStorageManager()
+        self.manager._client = MagicMock()
+
+    def test_retrieve_parameter_not_found_raises_without_fallback(self):
+        self.manager._client.get_parameter.side_effect = Exception(
+            "ParameterNotFound: missing parameter"
+        )
+
+        with self.assertRaises(StorageError) as context:
+            self.manager.retrieve("/encryption/123456789012/uswe2/module/filter/key_iv")
+
+        self.assertTrue(
+            str(context.exception).startswith("Parameter not found"),
+            "Expected ParameterNotFound to raise an immediate StorageError",
+        )
+        self.assertFalse(hasattr(AwsSsmStorageManager, "_handle_legacy_parameter"))
+        self.manager._client.get_parameter.assert_called_once_with(
+            Name="/encryption/123456789012/uswe2/module/filter/key_iv",
+            WithDecryption=True,
+        )
+        self.assertEqual(self.manager._client.get_parameter.call_count, 1)
+
+    def test_retrieve_other_boto_error_raises_storage_error(self):
+        self.manager._client.get_parameter.side_effect = Exception("AccessDenied: nope")
+
+        with self.assertRaises(StorageError) as context:
+            self.manager.retrieve("/path/to/secret")
+
+        self.assertIn("Failed to retrieve parameter", str(context.exception))
+
+    def test_retrieve_success_returns_decoded_parameter_value(self):
+        value = {"aes_key": "abc", "iv": "def"}
+        self.manager._client.get_parameter.return_value = {
+            "Parameter": {"Value": json.dumps(value)}
+        }
+
+        result = self.manager.retrieve("/path/to/secret")
+
+        self.assertEqual(result, value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Removes the legacy SSM parameter-path migration shim from `AwsSsmStorageManager.retrieve()`.

Migration to region-namespaced SSM paths (`/encryption/{account}/{region}/{module}/{filter}/key_iv`) is complete, so the fallback to the old region-less path is no longer needed.

## Changes
- `retrieve()`: on `ParameterNotFound`, raise `StorageError` immediately — no fallback attempt.
- Deleted `_handle_legacy_parameter()` (the auto-copy-to-new-path shim).
- Added `tests/unit/test_aws_ssm_storage_manager.py` covering: not-found (single `get_parameter` call, no fallback, legacy method absent), generic boto error, and success.

## Verify
`poetry run pytest tests/unit/` — 45 passed (was 42; +3 new).