### PR TITLE
feat(cli): CLI UX/security hardening — namespace surfacing, rotate-key confirm, doctor, errors to stderr

### DIFF
--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -191,5 +191,8 @@ class AesKeyManager:
     def resolve_parameter_name(self, filter_name) -> str:
         return self._parameter_name(filter_name=filter_name)
 
+    def is_cached(self, filter_name) -> bool:
+        return os.path.exists(self._cache_path(filter_name))
+
     def _cache_path(self, filter_name: str) -> str:
         return os.path.join(self.cache_dir, f"{filter_name}_key_iv.json")

--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -188,5 +188,8 @@ class AesKeyManager:
             module_name=self.module_name, filter_name=filter_name
         )
 
+    def resolve_parameter_name(self, filter_name) -> str:
+        return self._parameter_name(filter_name=filter_name)
+
     def _cache_path(self, filter_name: str) -> str:
         return os.path.join(self.cache_dir, f"{filter_name}_key_iv.json")

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -1,16 +1,25 @@
 import argparse
 import configparser
+import os
 import sys
 from pathlib import Path
 
 from git_secret_protector.context.module import GitSecretProtectorModule
-from git_secret_protector.core.settings import get_settings
+from git_secret_protector.core.settings import Settings, get_settings
 from git_secret_protector.services.encryption_manager import EncryptionManager
 from git_secret_protector.utils.configure_logging import configure_logging
+from git_secret_protector.utils.project_version import get_project_version_from_metadata
 
 MODULE_FOLDER = ".git_secret_protector"
 
 manager = None
+
+
+def _safe_version():
+    try:
+        return get_project_version_from_metadata()
+    except Exception:
+        return "unknown"
 
 
 def init_module_folder():
@@ -105,7 +114,38 @@ def show_project_version(_):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Git Secret Protector CLI")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Encrypt selected repository files transparently with Git filters and "
+            "per-filter AES keys."
+        ),
+        epilog=(
+            "Typical workflow (repo owner):\n"
+            "  1. create .gitattributes mapping globs to filters\n"
+            "  2. git-secret-protector setup-filters\n"
+            "  3. git-secret-protector setup-aes-key <filter>\n"
+            "  4. edit/commit — files are encrypted transparently\n"
+            "Team member:\n"
+            "  git-secret-protector pull-aes-key <filter> && "
+            "git-secret-protector setup-filters"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"git-secret-protector {_safe_version()}",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=str,
+        default=None,
+        help=(
+            "Repo root to operate on (overrides auto-detection; same as the "
+            "SECRET_PROTECTOR_BASE_DIR env var). Must precede the subcommand."
+        ),
+    )
     subparsers = parser.add_subparsers(help="Available commands")
 
     # Add filter commands to the parser
@@ -184,6 +224,15 @@ def main():
     if hasattr(args, "func"):
         try:
             if args.func is not show_project_version:
+                if args.repo_root:
+                    repo_root = Path(args.repo_root)
+                    if not repo_root.is_dir():
+                        print(
+                            f"Error: --repo-root points to a missing directory: {args.repo_root}",
+                            file=sys.stderr,
+                        )
+                        sys.exit(1)
+                    os.environ[Settings.BASE_DIR_ENV_VAR] = args.repo_root
                 init_module_folder()
                 configure_logging()
                 global manager

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -234,14 +234,15 @@ def main():
         try:
             if args.func is not show_project_version:
                 if args.repo_root:
-                    repo_root = Path(args.repo_root)
+                    repo_root = Path(args.repo_root).resolve()
                     if not repo_root.is_dir():
                         print(
                             f"Error: --repo-root points to a missing directory: {args.repo_root}",
                             file=sys.stderr,
                         )
                         sys.exit(1)
-                    os.environ[Settings.BASE_DIR_ENV_VAR] = args.repo_root
+                    os.environ[Settings.BASE_DIR_ENV_VAR] = str(repo_root)
+                    os.chdir(repo_root)
                 init_module_folder()
                 configure_logging()
                 global manager

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -109,6 +109,10 @@ def status_command(_):
     manager.status()
 
 
+def doctor_command(_):
+    sys.exit(manager.doctor())
+
+
 def show_project_version(_):
     EncryptionManager.show_project_version()
 
@@ -215,6 +219,11 @@ def main():
         "status", help="List all filters and file statuses"
     )
     parser_status.set_defaults(func=status_command)
+
+    parser_doctor = subparsers.add_parser(
+        "doctor", help="Diagnose the git-secret-protector setup"
+    )
+    parser_doctor.set_defaults(func=doctor_command)
 
     # Version command
     parser_status = subparsers.add_parser("version", help="Show version")

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -68,7 +68,7 @@ def pull_aes_key(args):
 
 def rotate_key(args):
     filter_name = args.filter_name
-    manager.rotate_keys(filter_name=filter_name)
+    manager.rotate_keys(filter_name=filter_name, assume_yes=getattr(args, "yes", False))
 
 
 def decrypt_stdin(args):
@@ -89,11 +89,6 @@ def decrypt_files_by_filter(args):
 def encrypt_files_by_filter(args):
     filter_name = args.filter_name
     manager.encrypt_files(filter_name=filter_name)
-
-
-def destroy_aes_key(args):
-    filter_name = args.filter_name
-    manager.setup_aes_key(filter_name=filter_name)
 
 
 def clean_filter(args):
@@ -117,7 +112,6 @@ def main():
     filter_commands = [
         ("setup-aes-key", setup_aes_key, "Set up AES key for a filter"),
         ("pull-aes-key", pull_aes_key, "Pull AES key for a filter"),
-        ("rotate-key", rotate_key, "Rotate AES key and re-encrypt secrets"),
         (
             "decrypt-files",
             decrypt_files_by_filter,
@@ -161,6 +155,20 @@ def main():
             "filter_name", type=str, nargs="?", help="The filter name"
         )
         parser_cmd.set_defaults(func=func)
+
+    parser_rotate_key = subparsers.add_parser(
+        "rotate-key", help="Rotate AES key and re-encrypt secrets"
+    )
+    parser_rotate_key.add_argument(
+        "filter_name", type=str, nargs="?", help="The filter name"
+    )
+    parser_rotate_key.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip the rotate confirmation prompt",
+    )
+    parser_rotate_key.set_defaults(func=rotate_key)
 
     # Status command
     parser_status = subparsers.add_parser(

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -41,7 +41,27 @@ class EncryptionManager:
             except Exception:
                 pass
 
+    def _require_filter(self, filter_name):
+        if filter_name:
+            return filter_name
+        try:
+            available = self.git_attributes_parser.get_filter_names()
+        except Exception:
+            available = []
+        if available:
+            msg = (
+                f"a filter name is required. Available filters: {', '.join(available)}"
+            )
+        else:
+            msg = (
+                "a filter name is required. No filters defined "
+                "(.gitattributes missing or empty)."
+            )
+        print(f"Error: {msg}", file=sys.stderr)
+        sys.exit(1)
+
     def setup_aes_key(self, filter_name: str):
+        filter_name = self._require_filter(filter_name)
         self._print_context(filter_name)
         try:
             logger.info("Setting up AES key for filter: %s", filter_name)
@@ -62,6 +82,7 @@ class EncryptionManager:
         print("Successfully set up filters")
 
     def pull_aes_key(self, filter_name: str):
+        filter_name = self._require_filter(filter_name)
         self._print_context(filter_name)
         try:
             logger.info("Pulling AES key for filter: %s", filter_name)
@@ -74,6 +95,7 @@ class EncryptionManager:
             sys.exit(1)
 
     def encrypt_files(self, filter_name: str):
+        filter_name = self._require_filter(filter_name)
         try:
             logger.info("Encrypting files for filter: %s", filter_name)
             files_to_encrypt = self.git_attributes_parser.get_files_for_filter(
@@ -94,6 +116,7 @@ class EncryptionManager:
             sys.exit(1)
 
     def decrypt_files(self, filter_name: str):
+        filter_name = self._require_filter(filter_name)
         try:
             logger.info("Decrypting files for filter: %s", filter_name)
             files_to_decrypt = self.git_attributes_parser.get_files_for_filter(
@@ -176,6 +199,7 @@ class EncryptionManager:
             sys.stdout.buffer.flush()
 
     def rotate_keys(self, filter_name: str, assume_yes: bool = False):
+        filter_name = self._require_filter(filter_name)
         self._print_context(filter_name)
         try:
             if not assume_yes:
@@ -195,6 +219,7 @@ class EncryptionManager:
             sys.exit(1)
 
     def clean_filter(self, filter_name: str):
+        filter_name = self._require_filter(filter_name)
         try:
             logger.info("Cleaning staged data for filter: %s", filter_name)
 

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -204,11 +204,19 @@ class EncryptionManager:
         self._print_context(filter_name)
         try:
             if not assume_yes:
-                answer = input(
-                    f"Rotate key for filter '{filter_name}'? This re-encrypts ALL matched files and retires the current key. [y/N] "
-                )
+                try:
+                    answer = input(
+                        f"Rotate key for filter '{filter_name}'? This re-encrypts ALL matched files and retires the current key. [y/N] "
+                    )
+                except EOFError:
+                    # No TTY (CI / piped stdin) and no explicit consent — treat as
+                    # a decline so a destructive rotation never runs unconfirmed.
+                    answer = ""
                 if answer.strip().lower() not in {"y", "yes"}:
-                    print("Aborted.", file=sys.stderr)
+                    print(
+                        "Aborted (no confirmation; pass -y/--yes for non-interactive use).",
+                        file=sys.stderr,
+                    )
                     return
             rotator = KeyRotator(self.key_manager, self.git_attributes_parser)
             rotator.rotate_key(filter_name)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -255,6 +256,83 @@ class EncryptionManager:
         except Exception as e:
             print(f"Status command failed: {e}", file=sys.stderr)
             sys.exit(1)
+
+    def doctor(self) -> int:
+        settings = get_settings()
+        failed = False
+
+        print("[ OK ] Repository context")
+        print(f"  base_dir: {settings.base_dir}")
+        print(f"  backend: {settings.storage_type.value}")
+        print(f"  module_name: {settings.module_name}")
+
+        if os.path.exists(settings.config_file):
+            print(f"[ OK ] config.ini found at {settings.config_file}")
+        else:
+            print("[WARN] config.ini not found (defaults in use)")
+
+        filter_names = []
+        try:
+            filter_names = self.git_attributes_parser.get_filter_names()
+        except Exception:
+            pass
+
+        if not filter_names:
+            print("[WARN] no filters defined in .gitattributes")
+            return 1 if failed else 0
+
+        print(f"[ OK ] filters declared: {', '.join(filter_names)}")
+
+        for filter_name in filter_names:
+            check_clean = subprocess.run(
+                ["git", "config", "--get", f"filter.{filter_name}.clean"],
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            check_smudge = subprocess.run(
+                ["git", "config", "--get", f"filter.{filter_name}.smudge"],
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            if check_clean and check_smudge:
+                print(f"[ OK ] filter '{filter_name}' configured in .git/config")
+            else:
+                print(
+                    f"[WARN] filter '{filter_name}' not configured in .git/config (run setup-filters)"
+                )
+
+            if self.key_manager.is_cached(filter_name):
+                print(f"[ OK ] local key cache exists for '{filter_name}'")
+            else:
+                print(
+                    f"[WARN] no local key cache for '{filter_name}' (run pull-aes-key)"
+                )
+
+        try:
+            self.key_manager.resolve_parameter_name(filter_names[0])
+            print("[ OK ] backend reachable")
+        except Exception:
+            print("[WARN] backend not reachable / no credentials (offline ok)")
+
+        for filter_name in filter_names:
+            files = self.git_attributes_parser.get_files_for_filter(filter_name)
+            plaintext_files = []
+
+            for file_path in files:
+                if not self.__is_encrypted(file_path):
+                    plaintext_files.append(file_path)
+                    failed = True
+                    print(
+                        f"[FAIL] {file_path} is tracked as secret but is PLAINTEXT in the working tree"
+                    )
+
+            if not plaintext_files:
+                print(
+                    f"[ OK ] all tracked secret files are encrypted for '{filter_name}'"
+                )
+
+        return 1 if failed else 0
 
     @staticmethod
     def show_project_version():

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -309,11 +309,14 @@ class EncryptionManager:
                     f"[WARN] no local key cache for '{filter_name}' (run pull-aes-key)"
                 )
 
+        # Resolving the parameter name forces credential/region resolution
+        # (e.g. an STS call for AWS SSM). It confirms creds + config resolve,
+        # not that the key parameter exists or that a full fetch would succeed.
         try:
             self.key_manager.resolve_parameter_name(filter_names[0])
-            print("[ OK ] backend reachable")
+            print("[ OK ] backend credentials/region resolved")
         except Exception:
-            print("[WARN] backend not reachable / no credentials (offline ok)")
+            print("[WARN] backend credentials/region unresolved (offline ok)")
 
         for filter_name in filter_names:
             files = self.git_attributes_parser.get_files_for_filter(filter_name)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -28,7 +28,21 @@ class EncryptionManager:
         self.key_rotator = key_rotator
         self.magic_header = get_settings().magic_header.encode()
 
+    def _print_context(self, filter_name=None):
+        settings = get_settings()
+        print(f"Backend:   {settings.storage_type.value}", file=sys.stderr)
+        print(f"Module:    {settings.module_name}", file=sys.stderr)
+        print(f"Repo root: {settings.base_dir}", file=sys.stderr)
+
+        if filter_name is not None:
+            try:
+                path = self.key_manager.resolve_parameter_name(filter_name)
+                print(f"Namespace: {path}", file=sys.stderr)
+            except Exception:
+                pass
+
     def setup_aes_key(self, filter_name: str):
+        self._print_context(filter_name)
         try:
             logger.info("Setting up AES key for filter: %s", filter_name)
             self.key_manager.setup_aes_key_and_iv(filter_name)
@@ -36,7 +50,7 @@ class EncryptionManager:
             print(f"Successfully set up AES key for filter: {filter_name}")
         except Exception as e:
             logger.error(f"AES key setup command failed: {e}", exc_info=True)
-            print(f"AES key setup command failed: {e}")
+            print(f"AES key setup command failed: {e}", file=sys.stderr)
             sys.exit(1)
 
     def setup_filters(self):
@@ -48,6 +62,7 @@ class EncryptionManager:
         print("Successfully set up filters")
 
     def pull_aes_key(self, filter_name: str):
+        self._print_context(filter_name)
         try:
             logger.info("Pulling AES key for filter: %s", filter_name)
             self.key_manager.retrieve_key_and_iv(filter_name=filter_name)
@@ -55,7 +70,7 @@ class EncryptionManager:
             print(f"Successfully pulled AES key for filter: {filter_name}")
         except Exception as e:
             logger.error(f"Pull AES key command failed: {e}", exc_info=True)
-            print(f"Pull AES key command failed: {e}")
+            print(f"Pull AES key command failed: {e}", file=sys.stderr)
             sys.exit(1)
 
     def encrypt_files(self, filter_name: str):
@@ -75,7 +90,7 @@ class EncryptionManager:
             print(f"Successfully encrypted files for filter: {filter_name}")
         except Exception as e:
             logger.error(f"Encrypt files command failed: {e}", exc_info=True)
-            print(f"Encrypt files command failed: {str(e)}")
+            print(f"Encrypt files command failed: {str(e)}", file=sys.stderr)
             sys.exit(1)
 
     def decrypt_files(self, filter_name: str):
@@ -95,7 +110,7 @@ class EncryptionManager:
             print(f"Successfully decrypted files for filter: {filter_name}")
         except Exception as e:
             logger.error(f"Decrypt files command failed: {e}", exc_info=True)
-            print(f"Decrypt files command failed: {e}")
+            print(f"Decrypt files command failed: {e}", file=sys.stderr)
             sys.exit(1)
 
     def encrypt_stdin(self, file_name):
@@ -160,15 +175,23 @@ class EncryptionManager:
             sys.stdout.buffer.write(encrypted_data)
             sys.stdout.buffer.flush()
 
-    def rotate_keys(self, filter_name: str):
+    def rotate_keys(self, filter_name: str, assume_yes: bool = False):
+        self._print_context(filter_name)
         try:
+            if not assume_yes:
+                answer = input(
+                    f"Rotate key for filter '{filter_name}'? This re-encrypts ALL matched files and retires the current key. [y/N] "
+                )
+                if answer.strip().lower() not in {"y", "yes"}:
+                    print("Aborted.", file=sys.stderr)
+                    return
             rotator = KeyRotator(self.key_manager, self.git_attributes_parser)
             rotator.rotate_key(filter_name)
             logger.info("Key rotation complete for filter: %s", filter_name)
             print(f"Key rotation complete for filter: {filter_name}")
         except Exception as e:
             logger.error(f"Rotate keys command failed: {e}", exc_info=True)
-            print(f"Rotate keys command failed: {e}")
+            print(f"Rotate keys command failed: {e}", file=sys.stderr)
             sys.exit(1)
 
     def clean_filter(self, filter_name: str):
@@ -187,10 +210,11 @@ class EncryptionManager:
             print(f"Successfully cleaned staged data for filter: {filter_name}")
         except Exception as e:
             logger.error(f"Clean filter command failed: {e}", exc_info=True)
-            print(f"Clean filter command failed: {e}")
+            print(f"Clean filter command failed: {e}", file=sys.stderr)
             sys.exit(1)
 
     def status(self):
+        self._print_context()
         try:
             filter_names = self.git_attributes_parser.get_filter_names()
             for filter_name in filter_names:
@@ -199,12 +223,12 @@ class EncryptionManager:
                 if files:
                     for file in files:
                         encrypted = self.__is_encrypted(file_path=file)
-                        status = "Encrypted" if encrypted else "Decrypted"
+                        status = "Encrypted" if encrypted else "⚠ PLAINTEXT"
                         print(f"  {file}: {status}")
                 else:
                     print("  No files found for this filter.")
         except Exception as e:
-            print(f"Status command failed: {e}")
+            print(f"Status command failed: {e}", file=sys.stderr)
             sys.exit(1)
 
     @staticmethod
@@ -214,7 +238,7 @@ class EncryptionManager:
             print(f"git-secret-protector version: {version}")
         except Exception as e:
             logger.error(f"Failed to get project version: {e}", exc_info=True)
-            print(f"Failed to get project version: {str(e)}")
+            print(f"Failed to get project version: {str(e)}", file=sys.stderr)
 
     @staticmethod
     def _get_poetry_root_path():

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -304,6 +304,99 @@ class TestEncryptionManagerService(unittest.TestCase):
         self.assertIn("  enc.txt: Encrypted", output)
         self.assertIn("  plain.txt: ⚠ PLAINTEXT", output)
 
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_returns_zero_when_all_checks_are_green(self, mock_run):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        stdout = io.StringIO()
+
+        mock_run.side_effect = [
+            MagicMock(stdout="git-secret-protector encrypt %f\n"),
+            MagicMock(stdout="git-secret-protector decrypt %f\n"),
+        ]
+
+        with patch("os.path.exists", return_value=True):
+            with patch.object(
+                self.manager,
+                "_EncryptionManager__is_encrypted",
+                return_value=True,
+            ):
+                with contextlib.redirect_stdout(stdout):
+                    result = self.manager.doctor()
+
+        self.assertEqual(result, 0)
+        self.assertIn("[ OK ]", stdout.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_returns_one_when_plaintext_secret_file_detected(self, mock_run):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        stdout = io.StringIO()
+
+        mock_run.side_effect = [
+            MagicMock(stdout="git-secret-protector encrypt %f\n"),
+            MagicMock(stdout="git-secret-protector decrypt %f\n"),
+        ]
+
+        with patch("os.path.exists", return_value=True):
+            with patch.object(
+                self.manager,
+                "_EncryptionManager__is_encrypted",
+                return_value=False,
+            ):
+                with contextlib.redirect_stdout(stdout):
+                    result = self.manager.doctor()
+
+        self.assertEqual(result, 1)
+        self.assertIn("[FAIL]", stdout.getvalue())
+        self.assertIn("PLAINTEXT", stdout.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_warns_on_offline_backend_without_failing(self, mock_run):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.side_effect = RuntimeError("offline")
+        stdout = io.StringIO()
+
+        mock_run.side_effect = [
+            MagicMock(stdout="git-secret-protector encrypt %f\n"),
+            MagicMock(stdout="git-secret-protector decrypt %f\n"),
+        ]
+
+        with patch("os.path.exists", return_value=True):
+            with patch.object(
+                self.manager,
+                "_EncryptionManager__is_encrypted",
+                return_value=True,
+            ):
+                with contextlib.redirect_stdout(stdout):
+                    result = self.manager.doctor()
+
+        self.assertEqual(result, 0)
+        self.assertIn("[WARN] backend", stdout.getvalue())
+
+    def test_doctor_warns_when_gitattributes_missing_and_skips_per_filter_checks(self):
+        self.git_attributes_parser.get_filter_names.side_effect = FileNotFoundError(
+            "missing"
+        )
+        stdout = io.StringIO()
+
+        with patch("os.path.exists", return_value=True):
+            with contextlib.redirect_stdout(stdout):
+                result = self.manager.doctor()
+
+        self.assertEqual(result, 0)
+        output = stdout.getvalue()
+        self.assertIn("[WARN] no filters defined in .gitattributes", output)
+        self.assertNotIn(".git/config", output)
+        self.key_manager.is_cached.assert_not_called()
+        self.key_manager.resolve_parameter_name.assert_not_called()
+
     @patch("git_secret_protector.services.encryption_manager.get_settings")
     def test_status_prints_local_namespace_header_without_resolving_storage_path(
         self, mock_get_settings

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import io
 import json
 import os
@@ -90,6 +91,9 @@ class TestEncryptionManagerService(unittest.TestCase):
     def setUp(self, mock_get_settings):
         mock_settings = MagicMock()
         mock_settings.magic_header = generate_random_string()
+        mock_settings.storage_type.value = "AWS_SSM"
+        mock_settings.module_name = "git-secret-protector"
+        mock_settings.base_dir = "/repo/root"
         mock_get_settings.return_value = mock_settings
 
         self.git_attributes_parser = MagicMock(spec=GitAttributesParser)
@@ -155,11 +159,124 @@ class TestEncryptionManagerService(unittest.TestCase):
 
     def test_pull_aes_key_exits_non_zero_when_retrieve_raises(self):
         self.key_manager.retrieve_key_and_iv.side_effect = RuntimeError("boom")
+        stdout = io.StringIO()
+        stderr = io.StringIO()
 
-        with self.assertRaises(SystemExit) as context:
-            self.manager.pull_aes_key("secret")
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as context:
+                self.manager.pull_aes_key("secret")
 
         self.assertEqual(context.exception.code, 1)
+        self.assertNotIn("Pull AES key command failed", stdout.getvalue())
+        self.assertIn("Pull AES key command failed: boom", stderr.getvalue())
+
+    def test_encrypt_files_failure_prints_to_stderr_only(self):
+        self.git_attributes_parser.get_files_for_filter.side_effect = RuntimeError(
+            "boom"
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as context:
+                self.manager.encrypt_files("secret")
+
+        self.assertEqual(context.exception.code, 1)
+        self.assertNotIn("Encrypt files command failed", stdout.getvalue())
+        self.assertIn("Encrypt files command failed: boom", stderr.getvalue())
+
+    def test_status_failure_prints_to_stderr_only(self):
+        self.git_attributes_parser.get_filter_names.side_effect = RuntimeError("boom")
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as context:
+                self.manager.status()
+
+        self.assertEqual(context.exception.code, 1)
+        self.assertNotIn("Status command failed", stdout.getvalue())
+        self.assertIn("Status command failed: boom", stderr.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.KeyRotator")
+    @patch("builtins.input", return_value="n")
+    def test_rotate_keys_returns_on_negative_confirmation(
+        self, mock_input, mock_key_rotator
+    ):
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            self.manager.rotate_keys("secret")
+
+        mock_input.assert_called_once()
+        mock_key_rotator.assert_not_called()
+        self.assertIn("Aborted.", stderr.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.KeyRotator")
+    @patch("builtins.input", return_value="y")
+    def test_rotate_keys_proceeds_on_positive_confirmation(
+        self, mock_input, mock_key_rotator
+    ):
+        rotator = mock_key_rotator.return_value
+
+        self.manager.rotate_keys("secret")
+
+        mock_input.assert_called_once()
+        rotator.rotate_key.assert_called_once_with("secret")
+
+    @patch("git_secret_protector.services.encryption_manager.KeyRotator")
+    @patch("builtins.input", side_effect=AssertionError("input should not be called"))
+    def test_rotate_keys_assume_yes_skips_confirmation(
+        self, mock_input, mock_key_rotator
+    ):
+        rotator = mock_key_rotator.return_value
+
+        self.manager.rotate_keys("secret", assume_yes=True)
+
+        mock_input.assert_not_called()
+        rotator.rotate_key.assert_called_once_with("secret")
+
+    def test_status_marks_plaintext_files(self):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "enc.txt",
+            "plain.txt",
+        ]
+        stdout = io.StringIO()
+
+        with patch.object(
+            self.manager,
+            "_EncryptionManager__is_encrypted",
+            side_effect=[True, False],
+        ):
+            with contextlib.redirect_stdout(stdout):
+                self.manager.status()
+
+        output = stdout.getvalue()
+        self.assertIn("  enc.txt: Encrypted", output)
+        self.assertIn("  plain.txt: ⚠ PLAINTEXT", output)
+
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def test_status_prints_local_namespace_header_without_resolving_storage_path(
+        self, mock_get_settings
+    ):
+        mock_settings = MagicMock()
+        mock_settings.storage_type.value = "AWS_SSM"
+        mock_settings.module_name = "git-secret-protector"
+        mock_settings.base_dir = "/repo/root"
+        mock_get_settings.return_value = mock_settings
+        self.git_attributes_parser.get_filter_names.return_value = []
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            self.manager.status()
+
+        self.key_manager.resolve_parameter_name.assert_not_called()
+        output = stderr.getvalue()
+        self.assertIn("Backend:   AWS_SSM", output)
+        self.assertIn("Module:    git-secret-protector", output)
+        self.assertIn("Repo root: /repo/root", output)
 
     def test_decrypt_stdin_does_not_exit_when_decryption_raises(self):
         self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -105,6 +105,54 @@ class TestEncryptionManagerService(unittest.TestCase):
             key_rotator=self.key_rotator,
         )
 
+    def test_guarded_methods_require_filter_and_list_available_filters(self):
+        self.git_attributes_parser.get_filter_names.return_value = ["a", "b"]
+        methods = [
+            ("setup_aes_key", lambda: self.manager.setup_aes_key("")),
+            ("pull_aes_key", lambda: self.manager.pull_aes_key(None)),
+            ("encrypt_files", lambda: self.manager.encrypt_files("")),
+            ("decrypt_files", lambda: self.manager.decrypt_files(None)),
+            ("rotate_keys", lambda: self.manager.rotate_keys("", assume_yes=True)),
+            ("clean_filter", lambda: self.manager.clean_filter(None)),
+        ]
+
+        for name, invoke in methods:
+            with self.subTest(method=name):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(
+                    stderr
+                ):
+                    with self.assertRaises(SystemExit) as context:
+                        invoke()
+
+                self.assertEqual(context.exception.code, 1)
+                self.assertIn("Available filters: a, b", stderr.getvalue())
+                self.assertEqual(stdout.getvalue(), "")
+
+        self.key_manager.setup_aes_key_and_iv.assert_not_called()
+        self.key_manager.retrieve_key_and_iv.assert_not_called()
+        self.key_manager.remove_key_iv_from_cache.assert_not_called()
+        self.key_rotator.rotate_key.assert_not_called()
+
+    def test_require_filter_handles_missing_gitattributes_without_traceback(self):
+        self.git_attributes_parser.get_filter_names.side_effect = FileNotFoundError(
+            "missing"
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as context:
+                self.manager.pull_aes_key(None)
+
+        self.assertEqual(context.exception.code, 1)
+        self.assertIn("No filters defined", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.key_manager.retrieve_key_and_iv.assert_not_called()
+
     def test_encrypt_stdin_exits_non_zero_and_writes_nothing_when_encryption_raises(
         self,
     ):

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -258,7 +258,21 @@ class TestEncryptionManagerService(unittest.TestCase):
 
         mock_input.assert_called_once()
         mock_key_rotator.assert_not_called()
-        self.assertIn("Aborted.", stderr.getvalue())
+        self.assertIn("Aborted", stderr.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.KeyRotator")
+    @patch("builtins.input", side_effect=EOFError)
+    def test_rotate_keys_aborts_cleanly_on_eof(self, mock_input, mock_key_rotator):
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            # No SystemExit: EOF (piped/CI stdin) is a decline, not a crash.
+            self.manager.rotate_keys("secret")
+
+        mock_input.assert_called_once()
+        mock_key_rotator.assert_not_called()
+        self.assertIn("Aborted", stderr.getvalue())
+        self.assertNotIn("Rotate keys command failed", stderr.getvalue())
 
     @patch("git_secret_protector.services.encryption_manager.KeyRotator")
     @patch("builtins.input", return_value="y")

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -89,6 +89,20 @@ def test_repo_root_before_subcommand_missing_directory_errors(tmp_path):
     assert "missing directory" in result.stderr
 
 
+def test_repo_root_before_doctor_scans_target_repo(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    _init_git_repo(target)
+    (target / ".gitattributes").write_text("secret.env filter=app\n")
+    (target / "secret.env").write_text("PLAINTEXT\n")
+
+    result = _run_main(["--repo-root", str(target), "doctor"], tmp_path)
+
+    assert result.returncode == 1
+    assert "[FAIL]" in result.stdout
+    assert "PLAINTEXT" in result.stdout
+
+
 def test_help_includes_typical_workflow_epilog(tmp_path):
     result = _run_main(["--help"], tmp_path)
 

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -27,6 +27,16 @@ def _run_main(args, tmp_path):
     )
 
 
+def _init_git_repo(tmp_path):
+    subprocess.run(
+        ["git", "init"],
+        cwd=str(tmp_path),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_status_outside_git_repo_exits_cleanly(tmp_path):
     result = _run_main(["status"], tmp_path)
 
@@ -40,3 +50,47 @@ def test_help_outside_git_repo_still_works(tmp_path):
 
     assert result.returncode == 0
     assert "usage" in result.stdout
+
+
+def test_version_flag_outside_git_repo_works(tmp_path):
+    result = _run_main(["--version"], tmp_path)
+
+    assert result.returncode == 0
+    assert "git-secret-protector" in result.stdout
+
+
+def test_short_version_flag_outside_git_repo_works(tmp_path):
+    result = _run_main(["-V"], tmp_path)
+
+    assert result.returncode == 0
+    assert "git-secret-protector" in result.stdout
+
+
+def test_repo_root_before_subcommand_uses_override(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_git_repo(repo_root)
+    (repo_root / ".gitattributes").write_text("*.secret filter=secret\n")
+    (repo_root / "example.secret").write_text("plain\n")
+
+    result = _run_main(["--repo-root", str(repo_root), "status"], tmp_path)
+
+    assert result.returncode == 0
+    assert "git repository" not in result.stderr
+    assert "Filter: secret" in result.stdout
+
+
+def test_repo_root_before_subcommand_missing_directory_errors(tmp_path):
+    missing = tmp_path / "missing"
+
+    result = _run_main(["--repo-root", str(missing), "status"], tmp_path)
+
+    assert result.returncode == 1
+    assert "missing directory" in result.stderr
+
+
+def test_help_includes_typical_workflow_epilog(tmp_path):
+    result = _run_main(["--help"], tmp_path)
+
+    assert result.returncode == 0
+    assert "Typical workflow" in result.stdout


### PR DESCRIPTION
## Summary

### Why
The `git-secret-protector` CLI gave the operator little signal about *where* it was acting (which SSM namespace / repo root — the root cause of the silent-misconfiguration bug class), performed a destructive `rotate-key` with no confirmation, reported plaintext secret files neutrally, and wrote diagnostics to stdout. Several discoverability gaps (no `--version` flag, no `--repo-root`, thin `--help`, a no-op on a missing filter) rounded out the friction.

### What
End-user-focused UX + safety hardening of the CLI (P1 + P2 + the `doctor` command from the review):

- **Namespace surfacing** — `status` and key ops print backend / module / repo-root to stderr (local, no network); key ops best-effort print the resolved storage path.
- **Safe `rotate-key`** — interactive `[y/N]` confirm before re-encrypting; `-y/--yes` for CI; EOF (piped/non-interactive stdin) is treated as a clean decline, never an unconfirmed rotation.
- **Fail-open warning** — `status` flags tracked-but-plaintext files as `⚠ PLAINTEXT`.
- **Diagnostics → stderr** — all error/diagnostic output off stdout; success messages unchanged.
- **`-V/--version`** flag; **`--repo-root`** flag (sets the base dir *and* `chdir`s so file scans target the right repo); richer `--help` workflow epilog.
- **Clear filter-required error** listing available filters instead of operating on a literal `None`.
- **`doctor`** command — one-shot setup diagnostics (repo/backend/config/filter-wiring/key-cache/credentials/encryption), exits 1 on a plaintext tracked file.
- Removed dead, unregistered `destroy_aes_key` helper.

### Solution
Context surfacing and error routing live in `EncryptionManager`; flags and the `chdir`/env wiring live in `main.py`. The `--repo-root` `chdir` is load-bearing: without it the flag redirected only the namespace, leaving cwd-relative file globs and `git config` checks pointed at the wrong repo — a fail-open caught in review and locked with an integration test. All new behavior is additive; existing success-path output is untouched.

## Types of Changes

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- `poetry run pytest tests/unit/` — 65 passing (20 new across CLI flags, namespace header, rotate confirm/EOF, plaintext flag, `doctor`, and a `--repo-root` integration test that fail-opens without the `chdir` fix).
- Manual: `--version`, `--help`, `--repo-root <other-repo> doctor` (now `[FAIL]` exit 1 on a plaintext secret), filter-omitted error.

## Related Issues
Follow-ups (separate PRs): resolve `GitAttributesParser` globs against the resolved base dir (subdirectory invocations); `--quiet/--verbose/--json` output controls; interactive `init`.
