### PR TITLE
fix(parser): anchor file globbing to base_dir instead of cwd

### DIFF
--- a/src/git_secret_protector/core/git_attributes_parser.py
+++ b/src/git_secret_protector/core/git_attributes_parser.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 class GitAttributesParser:
     def __init__(self):
         settings = get_settings()
-        self.git_attributes_file = os.path.join(settings.base_dir, '.gitattributes')
+        self.base_dir = settings.base_dir
+        self.git_attributes_file = os.path.join(settings.base_dir, ".gitattributes")
         self._patterns = None
 
     @property
@@ -21,15 +22,17 @@ class GitAttributesParser:
             self._patterns = self._parse_patterns()
         return self._patterns
 
-    def get_secret_files(self, repo_root='.'):
+    def get_secret_files(self, repo_root=None):
         """Return all files matching any of the filter patterns."""
+        repo_root = self.base_dir if repo_root is None else repo_root
         secret_files = set()
         for patterns in self.patterns.values():
             secret_files.update(self._find_files_matching_patterns(patterns, repo_root))
         return list(secret_files)
 
-    def get_files_for_filter(self, filter_name, repo_root='.'):
+    def get_files_for_filter(self, filter_name, repo_root=None):
         """Return all files matching the patterns for a specific filter name."""
+        repo_root = self.base_dir if repo_root is None else repo_root
         patterns = self.patterns.get(filter_name, [])
         return self._find_files_matching_patterns(patterns, repo_root)
 
@@ -37,8 +40,9 @@ class GitAttributesParser:
         """Return a list of unique filter names from the .gitattributes file."""
         return list(self.patterns.keys())
 
-    def get_filter_name_for_file(self, file_name, repo_root='.'):
+    def get_filter_name_for_file(self, file_name, repo_root=None):
         """Return the filter name that matches the given file name based on .gitattributes patterns."""
+        repo_root = self.base_dir if repo_root is None else repo_root
         for filter_name, patterns in self.patterns.items():
             for pattern in patterns:
                 if fnmatch.fnmatch(os.path.relpath(file_name, repo_root), pattern):
@@ -48,9 +52,9 @@ class GitAttributesParser:
     def _parse_patterns(self):
         """Parse the .gitattributes file to extract patterns associated with filters."""
         patterns = {}
-        with open(self.git_attributes_file, 'r') as file:
+        with open(self.git_attributes_file, "r") as file:
             for line in file:
-                match = re.search(r'(.+)\s+filter=(\S+)', line)
+                match = re.search(r"(.+)\s+filter=(\S+)", line)
                 if match:
                     pattern = match.group(1).strip()
                     filter_name = match.group(2).strip()
@@ -59,8 +63,9 @@ class GitAttributesParser:
                     patterns[filter_name].append(pattern)
         return patterns
 
-    def _find_files_matching_patterns(self, patterns, repo_root='.'):
+    def _find_files_matching_patterns(self, patterns, repo_root=None):
         """Helper method to find files matching given patterns using glob."""
+        repo_root = self.base_dir if repo_root is None else repo_root
         matched_files = set()  # Using a set to avoid duplicates
         for pattern in patterns:
             files = glob.glob(os.path.join(repo_root, pattern), recursive=True)

--- a/tests/unit/test_git_attributes_parser.py
+++ b/tests/unit/test_git_attributes_parser.py
@@ -1,6 +1,8 @@
 import builtins
+import os
+import tempfile
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, Mock
 
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
 
@@ -75,6 +77,58 @@ database/*.sql filter=sqlfilter
             # Assert that all secret files from all filters are returned
             self.assertIn("/fake/repo/config/app.conf", secret_files)
             self.assertIn("/fake/repo/database/test.sql", secret_files)
+
+
+class TestGitAttributesParserBaseDirAnchoring(unittest.TestCase):
+    """Globbing must be anchored to settings.base_dir, not the process cwd.
+
+    Regression: running from a subdirectory of the repo previously scanned only
+    from cwd, missing files elsewhere in the repo (status/doctor fail-open).
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base_dir = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+
+        with _REAL_OPEN(os.path.join(self.base_dir, ".gitattributes"), "w") as f:
+            f.write("*.secret filter=secretfilter\n")
+            f.write("config/*.conf filter=configfilter\n")
+
+        with _REAL_OPEN(os.path.join(self.base_dir, "a.secret"), "w") as f:
+            f.write("x")
+        os.mkdir(os.path.join(self.base_dir, "config"))
+        with _REAL_OPEN(os.path.join(self.base_dir, "config", "app.conf"), "w") as f:
+            f.write("x")
+
+        # Run from a subdirectory so an unanchored ('.') glob would miss everything.
+        sub = os.path.join(self.base_dir, "sub")
+        os.mkdir(sub)
+        prev_cwd = os.getcwd()
+        os.chdir(sub)
+        self.addCleanup(os.chdir, prev_cwd)
+
+        stub_settings = Mock()
+        stub_settings.base_dir = self.base_dir
+        patcher = patch(
+            "git_secret_protector.core.git_attributes_parser.get_settings",
+            return_value=stub_settings,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_get_secret_files_anchored_to_base_dir_from_subdir(self):
+        parser = GitAttributesParser()
+        found = parser.get_secret_files()
+
+        self.assertIn(os.path.join(self.base_dir, "a.secret"), found)
+        self.assertIn(os.path.join(self.base_dir, "config", "app.conf"), found)
+
+    def test_get_files_for_filter_anchored_to_base_dir_from_subdir(self):
+        parser = GitAttributesParser()
+        found = parser.get_files_for_filter("secretfilter")
+
+        self.assertEqual(found, [os.path.join(self.base_dir, "a.secret")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

### Why
`GitAttributesParser` globbing defaulted `repo_root` to `'.'` (process cwd), so running `status` / `doctor` / `encrypt-files` / `decrypt-files` from a **subdirectory** of the repo scanned only from cwd and silently missed files elsewhere. This is a fail-open: `status` / `doctor` could report "all encrypted" without ever scanning the affected files.

### What
- `get_secret_files`, `get_files_for_filter`, `get_filter_name_for_file`, `_find_files_matching_patterns` now default `repo_root` to `settings.base_dir` instead of `'.'`.
- Added a regression test that invokes the parser from a subdirectory and asserts all tracked files across the repo are found.

### Solution
`repo_root` resolves to `self.base_dir` (captured at init) when not explicitly passed. `get_filter_name_for_file`'s `os.path.relpath(file_name, repo_root)` is preserved: git runs clean/smudge filters with cwd == repo root == base_dir, so resolving against base_dir yields the same per-file path and the per-file clean/smudge behavior is unchanged. Callers that pass an explicit `repo_root` (e.g. `--repo-root`) are unaffected.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- `poetry run pytest tests/unit/` — 67 passed.
- New tests `test_get_secret_files_anchored_to_base_dir_from_subdir` / `test_get_files_for_filter_anchored_to_base_dir_from_subdir` chdir into a subdir and assert files in the repo root and nested dirs are still found.
