### PR TITLE
feat(cli): output controls --quiet/--verbose/--json + bulk progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,22 @@ In case you need to rotate the AES key due to security reasons or a team member 
   git reset --hard
   ```
 
-### 4. Logging
+### 4. Output Control
+
+Three global flags control how the CLI produces output. They can be placed before or after the subcommand:
+
+- `--quiet` - suppress success and info messages; errors are still printed to stderr and exit codes are unchanged.
+- `--verbose` - emit internal log output to stderr for debugging.
+- `--json` - output machine-readable JSON. Supported for `status`, `doctor`, `version`, and the action commands (`setup-aes-key`, `pull-aes-key`, `rotate-key`, `encrypt-files`, `decrypt-files`). Action commands emit an `{ok, command, ...}` envelope; bulk operations (`encrypt-files`, `decrypt-files`) include a `counts` object with totals. Note: `--json` is ignored for the git-invoked `encrypt` and `decrypt` filter commands because their stdout is the raw file payload.
+
+```sh
+git-secret-protector status --json
+git-secret-protector doctor --json
+git-secret-protector --quiet encrypt-files my-secrets
+git-secret-protector --json status   # flag position before or after subcommand is equivalent
+```
+
+### 5. Logging
 
 Logs are stored in the `.git_secret_protector/logs/` directory by default, and you can configure the log level and file rotation in the `config.ini` file.
 

--- a/docs/plans/cli-output-controls/2026-06-22-cli-output-controls-plan.md
+++ b/docs/plans/cli-output-controls/2026-06-22-cli-output-controls-plan.md
@@ -1,0 +1,1035 @@
+# CLI Output Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--quiet` / `--verbose` / `--json` global flags and bulk progress to the `git-secret-protector` CLI.
+
+**Architecture:** A single `Output` object (`core/output.py`), configured once in `main()` from parsed flags and injector-bound, centralizes stdout/stderr/json routing. The `encrypt`/`decrypt` clean/smudge filter path is exempt (stdout is binary data). `status`/`doctor` build a structured dict and fork at the end on `output.json`.
+
+**Tech Stack:** Python 3.9, argparse, injector, stdlib json/logging. No new dependencies.
+
+## Global Constraints
+
+- Python 3.9 compatible; no new dependencies (no `tqdm`).
+- Formatter: `black` pinned `24.8.0`. Format only touched files.
+- `encrypt`/`decrypt` (stdin filter path) stdout MUST remain pure payload bytes under every flag combination. Never route their stdout through `Output`.
+- Human-mode output text of every command MUST stay byte-identical to current strings (snapshot-locked).
+- `--json` output is atomic: build the full dict, then dump once. Errors in json mode emit `{ok:false,...}` to stdout + nonzero exit.
+- Verbose console log handler MUST target `sys.stderr` explicitly, never stdout.
+- Test command: `poetry run pytest tests/unit/`.
+
+---
+
+## File Structure
+
+- Create `src/git_secret_protector/core/output.py` - the `Output` class.
+- Create `tests/unit/test_output.py` - Output unit tests.
+- Modify `src/git_secret_protector/utils/configure_logging.py` - optional stderr console handler.
+- Modify `src/git_secret_protector/context/module.py` - bind `Output`.
+- Modify `src/git_secret_protector/main.py` - parent parser, flag parse, mode resolve, build+bind Output.
+- Modify `src/git_secret_protector/services/encryption_manager.py` - route output via `Output`; dicts for status/doctor; envelopes; bulk progress.
+- Modify `tests/unit/test_encryption_manager.py` - update for Output, add json/progress/snapshot tests.
+- Modify `tests/unit/test_main_cli.py` - flag parsing + guard-rail stdout-purity tests.
+- Modify `README.md` - document the new flags.
+
+---
+
+### Task 1: `Output` class
+
+**Files:**
+- Create: `src/git_secret_protector/core/output.py`
+- Test: `tests/unit/test_output.py`
+
+**Interfaces:**
+- Produces: `Output(quiet=False, verbose=False, json=False)` with methods
+  `info(message: str) -> None`, `error(message: str) -> None`, `progress(message: str) -> None`,
+  `result(obj: dict) -> None`, and property `json -> bool`.
+- Routing: `info`/`progress` suppressed when `quiet` or `json`; `info` -> stdout, `progress` -> stderr.
+  `error` -> stderr always. `result` -> `json.dumps(obj)` + newline to stdout only when `json`, else no-op.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_output.py
+import contextlib
+import io
+import json
+import unittest
+
+from git_secret_protector.core.output import Output
+
+
+class TestOutput(unittest.TestCase):
+    def _capture(self, fn):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            fn()
+        return out.getvalue(), err.getvalue()
+
+    def test_normal_info_to_stdout(self):
+        out, err = self._capture(lambda: Output().info("hi"))
+        self.assertEqual(out, "hi\n")
+        self.assertEqual(err, "")
+
+    def test_error_to_stderr_always(self):
+        out, err = self._capture(lambda: Output(quiet=True).error("boom"))
+        self.assertEqual(out, "")
+        self.assertEqual(err, "boom\n")
+
+    def test_quiet_suppresses_info_and_progress(self):
+        out, err = self._capture(lambda: (Output(quiet=True).info("x"),
+                                          Output(quiet=True).progress("p")))
+        self.assertEqual(out, "")
+        self.assertEqual(err, "")
+
+    def test_progress_to_stderr_in_normal(self):
+        out, err = self._capture(lambda: Output().progress("[1/2] a"))
+        self.assertEqual(out, "")
+        self.assertEqual(err, "[1/2] a\n")
+
+    def test_json_result_to_stdout(self):
+        out, err = self._capture(lambda: Output(json=True).result({"ok": True}))
+        self.assertEqual(json.loads(out), {"ok": True})
+        self.assertEqual(err, "")
+
+    def test_json_suppresses_info_and_progress(self):
+        out, err = self._capture(lambda: (Output(json=True).info("x"),
+                                          Output(json=True).progress("p")))
+        self.assertEqual(out, "")
+        self.assertEqual(err, "")
+
+    def test_result_noop_in_human_mode(self):
+        out, err = self._capture(lambda: Output().result({"ok": True}))
+        self.assertEqual(out, "")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_output.py -v`
+Expected: FAIL with `ModuleNotFoundError: ... core.output`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/git_secret_protector/core/output.py
+import json as _json
+import sys
+
+
+class Output:
+    """Centralized CLI output router. Never used for the encrypt/decrypt
+    filter path, whose stdout carries binary file payload."""
+
+    def __init__(self, quiet=False, verbose=False, json=False):
+        self._quiet = quiet
+        self._verbose = verbose
+        self._json = json
+
+    @property
+    def json(self):
+        return self._json
+
+    @property
+    def verbose(self):
+        return self._verbose
+
+    def info(self, message):
+        if self._quiet or self._json:
+            return
+        print(message)
+
+    def error(self, message):
+        print(message, file=sys.stderr)
+
+    def progress(self, message):
+        if self._quiet or self._json:
+            return
+        print(message, file=sys.stderr)
+
+    def result(self, obj):
+        if not self._json:
+            return
+        print(_json.dumps(obj), file=sys.stdout)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_output.py -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git_secret_protector/core/output.py tests/unit/test_output.py
+git commit -m "feat(output): add Output router for CLI output modes"
+```
+
+---
+
+### Task 2: Verbose stderr log handler
+
+**Files:**
+- Modify: `src/git_secret_protector/utils/configure_logging.py`
+- Test: `tests/unit/test_configure_logging.py` (create)
+
+**Interfaces:**
+- Consumes: nothing from prior tasks.
+- Produces: `configure_logging(verbose: bool = False) -> None`. When `verbose`, adds a
+  `logging.StreamHandler(sys.stderr)` at `logging.DEBUG` in addition to the rotating file handler.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_configure_logging.py
+import logging
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+from git_secret_protector.utils.configure_logging import configure_logging
+
+
+class TestConfigureLogging(unittest.TestCase):
+    @patch("git_secret_protector.utils.configure_logging.get_settings")
+    def _run(self, verbose, mock_get_settings, tmp_log="/tmp/gsp-test.log"):
+        s = MagicMock()
+        s.log_file = tmp_log
+        s.log_level = "WARN"
+        s.log_max_size = 1048576
+        s.log_backup_count = 1
+        mock_get_settings.return_value = s
+        root = logging.getLogger()
+        root.handlers = []
+        configure_logging(verbose=verbose)
+        return root.handlers
+
+    def test_verbose_adds_stderr_stream_handler(self):
+        handlers = self._run(True)
+        stream = [h for h in handlers if isinstance(h, logging.StreamHandler)
+                  and not isinstance(h, logging.handlers.RotatingFileHandler)]
+        self.assertTrue(stream)
+        self.assertIs(stream[0].stream, sys.stderr)
+
+    def test_non_verbose_has_no_extra_stream_handler(self):
+        handlers = self._run(False)
+        stream = [h for h in handlers if type(h) is logging.StreamHandler]
+        self.assertEqual(stream, [])
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_configure_logging.py -v`
+Expected: FAIL with `TypeError: configure_logging() got an unexpected keyword argument 'verbose'`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/git_secret_protector/utils/configure_logging.py
+import logging
+import logging.handlers
+import os
+import sys
+
+from git_secret_protector.core.settings import get_settings
+
+
+def configure_logging(verbose=False):
+    settings = get_settings()
+    log_file = settings.log_file
+    log_level = settings.log_level
+    log_max_size = settings.log_max_size
+    log_backup_count = settings.log_backup_count
+
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    handler = logging.handlers.RotatingFileHandler(
+        log_file, maxBytes=log_max_size, backupCount=log_backup_count
+    )
+    handler.setFormatter(formatter)
+
+    handlers = [handler]
+    if verbose:
+        console = logging.StreamHandler(sys.stderr)
+        console.setFormatter(formatter)
+        console.setLevel(logging.DEBUG)
+        handlers.append(console)
+
+    logging.basicConfig(level=log_level, handlers=handlers)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_configure_logging.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git_secret_protector/utils/configure_logging.py tests/unit/test_configure_logging.py
+git commit -m "feat(logging): add opt-in verbose stderr console handler"
+```
+
+---
+
+### Task 3: Flags, mode resolution, injector binding in `main()`
+
+**Files:**
+- Modify: `src/git_secret_protector/context/module.py`
+- Modify: `src/git_secret_protector/main.py:120-256`
+- Test: `tests/unit/test_main_cli.py`
+
+**Interfaces:**
+- Consumes: `Output` (Task 1), `configure_logging(verbose=...)` (Task 2).
+- Produces: a parent parser exposing `--quiet`, `--verbose`, `--json`, `--repo-root`, inherited by
+  every subparser via `parents=[common]`; `main()` builds `Output(quiet, verbose, json)`, rejects
+  `--quiet --verbose`, binds the instance into the injector, and resolves `EncryptionManager` from it.
+- `GitSecretProtectorModule.set_output(output)` stores an instance bound via `binder.bind(Output, to=output)`.
+
+- [ ] **Step 1: Write the failing test** (append to `tests/unit/test_main_cli.py`)
+
+```python
+def test_quiet_and_verbose_conflict_exits_2(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+    result = _run_main(["--repo-root", str(repo), "--quiet", "--verbose", "status"], tmp_path)
+    assert result.returncode == 2
+    assert "quiet" in result.stderr.lower()
+
+
+def test_json_flag_after_subcommand_parses(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+    result = _run_main(["--repo-root", str(repo), "status", "--json"], tmp_path)
+    assert result.returncode == 0
+    import json
+    json.loads(result.stdout)  # stdout is a valid JSON document
+```
+
+(Reuse the existing `_run_main` / `_init_git_repo` helpers in this file. `_run_main` invokes the CLI in a subprocess; confirm its signature before writing and adapt argument passing.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_main_cli.py -k "conflict or json_flag_after" -v`
+Expected: FAIL (flags unknown / non-zero schema)
+
+- [ ] **Step 3: Implement module binding**
+
+```python
+# src/git_secret_protector/context/module.py
+import injector
+
+from git_secret_protector.core.git_attributes_parser import GitAttributesParser
+from git_secret_protector.core.output import Output
+from git_secret_protector.crypto.aes_key_manager import AesKeyManager
+
+
+class GitSecretProtectorModule(injector.Module):
+    _injector = None
+    _output = None
+
+    def configure(self, binder):
+        binder.bind(AesKeyManager, to=AesKeyManager, scope=injector.singleton)
+        binder.bind(
+            GitAttributesParser, to=GitAttributesParser, scope=injector.singleton
+        )
+        binder.bind(Output, to=self._output or Output(), scope=injector.singleton)
+
+    @classmethod
+    def set_output(cls, output):
+        cls._output = output
+        cls._injector = None  # force rebuild so the binding picks up the instance
+
+    @classmethod
+    def get_injector(cls):
+        if cls._injector is None:
+            cls._injector = injector.Injector(GitSecretProtectorModule())
+        return cls._injector
+```
+
+- [ ] **Step 4: Implement main() parent parser + mode resolution**
+
+In `src/git_secret_protector/main.py`, add imports:
+
+```python
+from git_secret_protector.core.output import Output
+```
+
+Replace the parser construction (lines 121-153) so a shared parent parser defines the global flags, and `subparsers` is created normally. Add to the parent:
+
+```python
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--repo-root", type=str, default=None, help=(
+        "Repo root to operate on (overrides auto-detection; same as the "
+        "SECRET_PROTECTOR_BASE_DIR env var)."))
+    common.add_argument("--quiet", action="store_true",
+                        help="Suppress success/info output (errors still shown).")
+    common.add_argument("--verbose", action="store_true",
+                        help="Show internal logs on stderr.")
+    common.add_argument("--json", action="store_true",
+                        help="Emit machine-readable JSON (status/doctor/version and "
+                             "action results; ignored for encrypt/decrypt).")
+```
+
+Add `parents=[common]` to the top-level parser AND to every `subparsers.add_parser(...)` call so the
+flags parse both before and after the subcommand. (Top-level keeps `-V/--version`.)
+
+Replace the dispatch block (lines 232-255) with:
+
+```python
+    args = parser.parse_args()
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+
+    if getattr(args, "quiet", False) and getattr(args, "verbose", False):
+        print("Error: --quiet and --verbose are mutually exclusive.", file=sys.stderr)
+        sys.exit(2)
+
+    output = Output(
+        quiet=getattr(args, "quiet", False),
+        verbose=getattr(args, "verbose", False),
+        json=getattr(args, "json", False),
+    )
+
+    try:
+        if args.func is not show_project_version:
+            if args.repo_root:
+                repo_root = Path(args.repo_root).resolve()
+                if not repo_root.is_dir():
+                    print(
+                        f"Error: --repo-root points to a missing directory: {args.repo_root}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                os.environ[Settings.BASE_DIR_ENV_VAR] = str(repo_root)
+                os.chdir(repo_root)
+            init_module_folder()
+            configure_logging(verbose=output.verbose)
+            GitSecretProtectorModule.set_output(output)
+            global manager
+            manager = GitSecretProtectorModule.get_injector().get(EncryptionManager)
+        else:
+            show_project_version(args, output)
+            return
+        args.func(args)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+```
+
+Note: `show_project_version` gains an `output` param in Task 4; until then keep its current
+call form. Implement Task 4 in the same wave to avoid a broken intermediate.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_main_cli.py -v`
+Expected: PASS (existing + 2 new). If `version`/`status` json assertions fail, they are completed in Tasks 4/6 - run those tasks in the same wave.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/git_secret_protector/context/module.py src/git_secret_protector/main.py tests/unit/test_main_cli.py
+git commit -m "feat(cli): add --quiet/--verbose/--json flags and Output wiring"
+```
+
+---
+
+> Tasks 4-8 modify `encryption_manager.py`. They share the constructor change below; apply it once in Task 4 and the later tasks build on it. Run Tasks 3-7 as one wave (they are interdependent through `main()` and the manager constructor).
+
+---
+
+### Task 4: Manager constructor + action-command output routing
+
+**Files:**
+- Modify: `src/git_secret_protector/services/encryption_manager.py`
+- Modify: `tests/unit/test_encryption_manager.py`
+
+**Interfaces:**
+- Consumes: `Output` (Task 1).
+- Produces: `EncryptionManager.__init__(self, git_attributes_parser, key_manager, key_rotator, output: Output = None)`
+  storing `self.output = output if output is not None else Output()`. Action commands route human text
+  through `self.output.info`/`self.output.error` and emit envelopes via `self.output.result`.
+- Envelope helper (private): `self._envelope_ok(command, **fields)` -> dict `{"ok": True, "command": command, **fields}`;
+  `self._envelope_err(command, error, **fields)` -> `{"ok": False, "command": command, "error": error, **fields}`.
+- `show_project_version` becomes an instance-aware static taking `output`: `show_project_version(_, output)`.
+
+- [ ] **Step 1: Write the failing test** (add to `TestEncryptionManagerService`)
+
+```python
+def test_setup_aes_key_json_envelope(self):
+    from git_secret_protector.core.output import Output
+    out = io.StringIO()
+    self.manager.output = Output(json=True)
+    with contextlib.redirect_stdout(out):
+        self.manager.setup_aes_key("secret")
+    payload = json.loads(out.getvalue())
+    self.assertEqual(payload, {"ok": True, "command": "setup-aes-key",
+                               "filter": "secret",
+                               "message": "Successfully set up AES key for filter: secret"})
+
+def test_setup_aes_key_json_error_envelope_and_exit(self):
+    from git_secret_protector.core.output import Output
+    self.key_manager.setup_aes_key_and_iv.side_effect = RuntimeError("boom")
+    out = io.StringIO()
+    self.manager.output = Output(json=True)
+    with contextlib.redirect_stdout(out):
+        with self.assertRaises(SystemExit) as ctx:
+            self.manager.setup_aes_key("secret")
+    self.assertEqual(ctx.exception.code, 1)
+    payload = json.loads(out.getvalue())
+    self.assertFalse(payload["ok"])
+    self.assertEqual(payload["command"], "setup-aes-key")
+    self.assertIn("boom", payload["error"])
+
+def test_setup_aes_key_human_text_unchanged(self):
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        self.manager.setup_aes_key("secret")
+    self.assertIn("Successfully set up AES key for filter: secret", out.getvalue())
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -k setup_aes_key_json -v`
+Expected: FAIL (no envelope; plain text printed)
+
+- [ ] **Step 3: Implement**
+
+Add the import and constructor change:
+
+```python
+from git_secret_protector.core.output import Output
+```
+
+```python
+    @injector.inject
+    def __init__(self, git_attributes_parser, key_manager, key_rotator, output: Output = None):
+        self.git_attributes_parser = git_attributes_parser
+        self.key_manager = key_manager
+        self.key_rotator = key_rotator
+        self.output = output if output is not None else Output()
+        self.magic_header = get_settings().magic_header.encode()
+
+    def _envelope_ok(self, command, **fields):
+        return {"ok": True, "command": command, **fields}
+
+    def _envelope_err(self, command, error, **fields):
+        return {"ok": False, "command": command, "error": error, **fields}
+```
+
+Convert `_print_context` to suppress under quiet (it already targets stderr):
+
+```python
+    def _print_context(self, filter_name=None):
+        if self.output._quiet:
+            return
+        settings = get_settings()
+        self.output.error(f"Backend:   {settings.storage_type.value}")
+        self.output.error(f"Module:    {settings.module_name}")
+        self.output.error(f"Repo root: {settings.base_dir}")
+        if filter_name is not None:
+            try:
+                path = self.key_manager.resolve_parameter_name(filter_name)
+                self.output.error(f"Namespace: {path}")
+            except Exception:
+                pass
+```
+
+Convert each action command. Pattern for `setup_aes_key` (apply the same shape to
+`pull_aes_key`, `setup_filters`, `clean_filter`, `rotate_keys`):
+
+```python
+    def setup_aes_key(self, filter_name: str):
+        filter_name = self._require_filter(filter_name)
+        self._print_context(filter_name)
+        try:
+            logger.info("Setting up AES key for filter: %s", filter_name)
+            self.key_manager.setup_aes_key_and_iv(filter_name)
+            logger.info("Successfully set up AES key for filter: %s", filter_name)
+            msg = f"Successfully set up AES key for filter: {filter_name}"
+            self.output.info(msg)
+            self.output.result(self._envelope_ok("setup-aes-key", filter=filter_name, message=msg))
+        except Exception as e:
+            logger.error(f"AES key setup command failed: {e}", exc_info=True)
+            self.output.error(f"AES key setup command failed: {e}")
+            self.output.result(self._envelope_err("setup-aes-key", str(e), filter=filter_name))
+            sys.exit(1)
+```
+
+Map command names: `pull-aes-key`, `setup-filters` (no filter field), `clean-filter`, `rotate-key`.
+For `rotate_keys` the abort-on-no-confirmation path emits `info`/`result` with
+`{"ok": False, "command": "rotate-key", "filter": ..., "message": "aborted"}` and returns (exit 0).
+`_require_filter` keeps `print(..., file=sys.stderr); sys.exit(1)` -> change its two `print` calls to
+`self.output.error(...)`; in json mode also emit `self.output.result(self._envelope_err(<cmd>, msg))`
+is NOT possible there (no command context) - leave `_require_filter` as a plain stderr error + exit
+(documented exception: pre-dispatch validation has no command envelope).
+
+Update `show_project_version`:
+
+```python
+    @staticmethod
+    def show_project_version(_=None, output=None):
+        output = output if output is not None else Output()
+        try:
+            version = get_project_version_from_metadata()
+            output.info(f"git-secret-protector version: {version}")
+            output.result({"version": version})
+        except Exception as e:
+            logger.error(f"Failed to get project version: {e}", exc_info=True)
+            output.error(f"Failed to get project version: {str(e)}")
+            output.result({"ok": False, "command": "version", "error": str(e)})
+```
+
+In `main.py`, `show_project_version(_)` handler wrapper becomes:
+
+```python
+def show_project_version(args):
+    EncryptionManager.show_project_version(args, _version_output(args))
+```
+
+where `_version_output(args)` builds `Output(quiet=..., verbose=..., json=...)` from args (version
+runs before the injector is wired). Simpler: inline the Output construction in the dispatch block
+already done in Task 3 (`show_project_version(args, output)`) - keep that single call site and drop
+the standalone handler's reliance on a global.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -v`
+Expected: PASS (existing + 3 new). Existing human-text assertions must still pass unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git_secret_protector/services/encryption_manager.py src/git_secret_protector/main.py tests/unit/test_encryption_manager.py
+git commit -m "feat(output): route action commands through Output with JSON envelopes"
+```
+
+---
+
+### Task 5: Bulk encrypt/decrypt - counts, per-file actions, progress
+
+**Files:**
+- Modify: `src/git_secret_protector/services/encryption_manager.py:98-138,230-248`
+- Modify: `tests/unit/test_encryption_manager.py`
+
+**Interfaces:**
+- Consumes: Task 4 constructor + envelopes; `self.__is_encrypted(path)`; handler `encrypt_file`/`decrypt_file`.
+- Produces: `encrypt_files(filter_name, emit=True)` and `decrypt_files(filter_name, emit=True)` that
+  iterate file-by-file, emit `progress` per file, tally `{"encrypted"/"decrypted", "skipped", "total"}`,
+  and (when `emit`) call `self.output.info` + `self.output.result(envelope)`. `clean_filter` calls
+  `self.encrypt_files(filter_name, emit=False)` to avoid a nested envelope.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_encrypt_files_progress_and_counts_json(self):
+    from git_secret_protector.core.output import Output
+    self.git_attributes_parser.get_files_for_filter.return_value = ["a.secret", "b.secret"]
+    out, err = io.StringIO(), io.StringIO()
+    self.manager.output = Output(json=True)
+    with patch.object(self.manager, "_EncryptionManager__get_encryption_handler") as h, \
+         patch.object(self.manager, "_EncryptionManager__is_encrypted", side_effect=[False, True]):
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            self.manager.encrypt_files("secret")
+    payload = json.loads(out.getvalue())
+    self.assertEqual(payload["counts"], {"encrypted": 1, "skipped": 1, "total": 2})
+    self.assertEqual(err.getvalue(), "")  # progress suppressed under json
+
+def test_encrypt_files_progress_to_stderr_in_normal(self):
+    self.git_attributes_parser.get_files_for_filter.return_value = ["a.secret", "b.secret"]
+    err = io.StringIO()
+    with patch.object(self.manager, "_EncryptionManager__get_encryption_handler"), \
+         patch.object(self.manager, "_EncryptionManager__is_encrypted", return_value=False):
+        with contextlib.redirect_stderr(err):
+            self.manager.encrypt_files("secret")
+    self.assertIn("[1/2] a.secret", err.getvalue())
+    self.assertIn("[2/2] b.secret", err.getvalue())
+
+def test_clean_filter_no_nested_envelope(self):
+    from git_secret_protector.core.output import Output
+    self.git_attributes_parser.get_files_for_filter.return_value = ["a.secret"]
+    out = io.StringIO()
+    self.manager.output = Output(json=True)
+    with patch.object(self.manager, "_EncryptionManager__get_encryption_handler"), \
+         patch.object(self.manager, "_EncryptionManager__is_encrypted", return_value=False):
+        with contextlib.redirect_stdout(out):
+            self.manager.clean_filter("secret")
+    payload = json.loads(out.getvalue())
+    self.assertEqual(payload["command"], "clean-filter")  # not encrypt-files
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -k "progress or nested_envelope" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+
+```python
+    def encrypt_files(self, filter_name: str, emit: bool = True):
+        filter_name = self._require_filter(filter_name)
+        try:
+            files = self.git_attributes_parser.get_files_for_filter(filter_name=filter_name)
+            if not files:
+                logging.info(f"No files to encrypt for filter: {filter_name}")
+                if emit:
+                    msg = f"No files to encrypt for filter: {filter_name}"
+                    self.output.info(msg)
+                    self.output.result(self._envelope_ok(
+                        "encrypt-files", filter=filter_name,
+                        counts={"encrypted": 0, "skipped": 0, "total": 0},
+                        files=[], message=msg))
+                return {"encrypted": 0, "skipped": 0, "total": 0}
+
+            handler = self.__get_encryption_handler(filter_name=filter_name)
+            total = len(files)
+            results = []
+            counts = {"encrypted": 0, "skipped": 0, "total": total}
+            for i, file in enumerate(files, 1):
+                self.output.progress(f"[{i}/{total}] {file}")
+                was_encrypted = self.__is_encrypted(file_path=file)
+                handler.encrypt_file(file)
+                action = "skipped" if was_encrypted else "encrypted"
+                counts[action] += 1
+                results.append({"path": file, "action": action})
+            logging.info(f"Successfully encrypted files for filter: {filter_name}")
+            if emit:
+                msg = f"Successfully encrypted files for filter: {filter_name}"
+                self.output.info(msg)
+                self.output.result(self._envelope_ok(
+                    "encrypt-files", filter=filter_name, counts=counts,
+                    files=results, message=msg))
+            return counts
+        except Exception as e:
+            logger.error(f"Encrypt files command failed: {e}", exc_info=True)
+            self.output.error(f"Encrypt files command failed: {str(e)}")
+            if emit:
+                self.output.result(self._envelope_err("encrypt-files", str(e), filter=filter_name))
+            sys.exit(1)
+```
+
+Mirror for `decrypt_files` (count key `decrypted`; action `decrypted`/`skipped`; decide skipped via
+`not self.__is_encrypted(file)` meaning already plaintext -> "skipped"). Command name `decrypt-files`.
+
+In `clean_filter`, change the internal call:
+
+```python
+            try:
+                self.encrypt_files(filter_name=filter_name, emit=False)
+            except SystemExit:
+                logger.warning("Failed to encrypt files for filter '%s' during clean", filter_name)
+```
+
+(Note: `encrypt_files` now `sys.exit(1)` on failure; clean_filter must catch `SystemExit` instead of
+`Exception` for the internal call, preserving its current best-effort behavior. The final
+`clean-filter` success envelope/message stays as in Task 4.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -v`
+Expected: PASS. The existing `test_guarded_methods_require_filter_and_list_available_filters` still
+passes (require_filter unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git_secret_protector/services/encryption_manager.py tests/unit/test_encryption_manager.py
+git commit -m "feat(output): bulk encrypt/decrypt counts, per-file progress, JSON envelope"
+```
+
+---
+
+### Task 6: `status --json`
+
+**Files:**
+- Modify: `src/git_secret_protector/services/encryption_manager.py:250-266`
+- Modify: `tests/unit/test_encryption_manager.py`
+
+**Interfaces:**
+- Consumes: Task 4 `self.output`.
+- Produces: `status()` builds the full dict, then forks: `if self.output.json: self.output.result(dict)`
+  else the existing human prints (byte-identical). On exception in json mode, emit error envelope.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_status_json_schema(self):
+    from git_secret_protector.core.output import Output
+    self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+    self.git_attributes_parser.get_files_for_filter.return_value = ["enc.txt", "plain.txt"]
+    out = io.StringIO()
+    self.manager.output = Output(json=True)
+    with patch.object(self.manager, "_EncryptionManager__is_encrypted", side_effect=[True, False]):
+        with contextlib.redirect_stdout(out):
+            self.manager.status()
+    payload = json.loads(out.getvalue())
+    self.assertEqual(payload["backend"], "AWS_SSM")
+    self.assertEqual(payload["filters"][0]["name"], "secret")
+    self.assertEqual(payload["filters"][0]["files"],
+                     [{"path": "enc.txt", "encrypted": True},
+                      {"path": "plain.txt", "encrypted": False}])
+
+def test_status_human_text_unchanged(self):
+    self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+    self.git_attributes_parser.get_files_for_filter.return_value = ["enc.txt", "plain.txt"]
+    out = io.StringIO()
+    with patch.object(self.manager, "_EncryptionManager__is_encrypted", side_effect=[True, False]):
+        with contextlib.redirect_stdout(out):
+            self.manager.status()
+    self.assertIn("  enc.txt: Encrypted", out.getvalue())
+    self.assertIn("  plain.txt: ⚠ PLAINTEXT", out.getvalue())
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -k status_json -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+
+```python
+    def status(self):
+        self._print_context()
+        try:
+            settings = get_settings()
+            filter_names = self.git_attributes_parser.get_filter_names()
+            data = {"repo_root": settings.base_dir,
+                    "backend": settings.storage_type.value,
+                    "module_name": settings.module_name,
+                    "filters": []}
+            for filter_name in filter_names:
+                files = self.git_attributes_parser.get_files_for_filter(filter_name)
+                file_entries = [{"path": f, "encrypted": self.__is_encrypted(file_path=f)}
+                                for f in files]
+                data["filters"].append({"name": filter_name, "files": file_entries})
+
+            if self.output.json:
+                self.output.result(data)
+                return
+
+            for entry in data["filters"]:
+                print(f"Filter: {entry['name']}")
+                if entry["files"]:
+                    for f in entry["files"]:
+                        status = "Encrypted" if f["encrypted"] else "⚠ PLAINTEXT"
+                        print(f"  {f['path']}: {status}")
+                else:
+                    print("  No files found for this filter.")
+        except Exception as e:
+            if self.output.json:
+                self.output.result(self._envelope_err("status", str(e)))
+            else:
+                self.output.error(f"Status command failed: {e}")
+            sys.exit(1)
+```
+
+Keep the human `print(...)` calls (not `output.info`) so behavior is byte-identical and independent
+of quiet for `status` (matches current; status is a report command). If quiet-suppression of the
+filter listing is desired later, that is a separate change.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -k status -v`
+Expected: PASS (existing `test_status_marks_plaintext_files` + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git_secret_protector/services/encryption_manager.py tests/unit/test_encryption_manager.py
+git commit -m "feat(status): add --json structured output"
+```
+
+---
+
+### Task 7: `doctor --json`
+
+**Files:**
+- Modify: `src/git_secret_protector/services/encryption_manager.py:268-346`
+- Modify: `tests/unit/test_encryption_manager.py`
+
+**Interfaces:**
+- Consumes: Task 4 `self.output`.
+- Produces: `doctor()` builds a `checks` list of `{"check", "status": "ok|warn|fail", "detail"}` and the
+  return code, then forks on `self.output.json`. Returns the int exit code in both modes; `main()`'s
+  `doctor_command` still `sys.exit`s with it.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@patch("git_secret_protector.services.encryption_manager.subprocess.run")
+def test_doctor_json_schema_and_exit(self, mock_run):
+    from git_secret_protector.core.output import Output
+    self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+    self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+    self.key_manager.is_cached.return_value = True
+    self.key_manager.resolve_parameter_name.return_value = "/path"
+    mock_run.side_effect = [MagicMock(stdout="x\n"), MagicMock(stdout="y\n")]
+    out = io.StringIO()
+    self.manager.output = Output(json=True)
+    with patch("os.path.exists", return_value=True), \
+         patch.object(self.manager, "_EncryptionManager__is_encrypted", return_value=False):
+        with contextlib.redirect_stdout(out):
+            rc = self.manager.doctor()
+    self.assertEqual(rc, 1)
+    payload = json.loads(out.getvalue())
+    self.assertFalse(payload["ok"])
+    self.assertEqual(payload["exit_code"], 1)
+    self.assertTrue(any(c["status"] == "fail" for c in payload["checks"]))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -k doctor_json -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+
+Refactor `doctor()` to accumulate `checks.append({"check","status","detail"})` for each existing
+check (repository_context, config_ini, filters_declared / no filters, per-filter git_config + key_cache,
+backend_credentials, per-filter plaintext_scan), keep `failed` for any `fail`, compute
+`exit_code = 1 if failed else 0`, then:
+
+```python
+        if self.output.json:
+            self.output.result({"ok": not failed, "exit_code": exit_code, "checks": checks})
+            return exit_code
+        # human mode: print each check with its existing label
+        for c in checks:
+            label = {"ok": "[ OK ]", "warn": "[WARN]", "fail": "[FAIL]"}[c["status"]]
+            print(f"{label} {c['detail']}")
+        return exit_code
+```
+
+Preserve the exact human lines: build each check's `detail` to equal the current printed text minus the
+label prefix (e.g. repository_context emits a multi-line block; keep it by appending the sub-lines into
+`detail` or by special-casing the human render for that check). Snapshot test below locks this.
+
+- [ ] **Step 4: Add human snapshot test + run**
+
+```python
+@patch("git_secret_protector.services.encryption_manager.subprocess.run")
+def test_doctor_human_text_unchanged(self, mock_run):
+    self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+    self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+    self.key_manager.is_cached.return_value = True
+    self.key_manager.resolve_parameter_name.return_value = "/path"
+    mock_run.side_effect = [MagicMock(stdout="x\n"), MagicMock(stdout="y\n")]
+    out = io.StringIO()
+    with patch("os.path.exists", return_value=True), \
+         patch.object(self.manager, "_EncryptionManager__is_encrypted", return_value=True):
+        with contextlib.redirect_stdout(out):
+            self.manager.doctor()
+    text = out.getvalue()
+    self.assertIn("[ OK ] filters declared: secret", text)
+    self.assertIn("[ OK ] all tracked secret files are encrypted for 'secret'", text)
+```
+
+Run: `poetry run pytest tests/unit/test_encryption_manager.py -k doctor -v`
+Expected: PASS (all existing doctor tests + 2 new). The existing tests assert substrings like
+`[ OK ]`, `[FAIL]`, `[WARN] backend`, `PLAINTEXT` - the `detail` strings MUST keep those substrings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git_secret_protector/services/encryption_manager.py tests/unit/test_encryption_manager.py
+git commit -m "feat(doctor): add --json structured output, preserve exit code"
+```
+
+---
+
+### Task 8: Guard-rail - encrypt/decrypt stdout purity under all flags
+
+**Files:**
+- Modify: `tests/unit/test_main_cli.py` (subprocess-level, exercises real flag parsing + filter path)
+
+**Interfaces:**
+- Consumes: full CLI. Asserts `encrypt`/`decrypt` stdout is exact payload bytes for flag combos
+  `[]`, `--json`, `--quiet`, `--verbose`.
+
+- [ ] **Step 1: Write the test**
+
+```python
+import itertools
+import subprocess
+
+def _run_main_stdin(argv, cwd, stdin_bytes):
+    return subprocess.run(
+        ["poetry", "run", "git-secret-protector", *argv],
+        cwd=str(cwd), input=stdin_bytes, capture_output=True,
+    )
+
+def test_encrypt_decrypt_stdout_is_pure_bytes_under_all_flags(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+    # set up a local key for the 'secret' filter via the CLI (or seed the cache fixture
+    # the other CLI tests use; reuse this file's existing key-setup helper if present).
+    flag_sets = [[], ["--json"], ["--quiet"], ["--verbose"]]
+    for flags in flag_sets:
+        enc = _run_main_stdin([*flags, "encrypt", "x.secret"], repo, b"hello-secret")
+        assert enc.returncode == 0, enc.stderr
+        # round-trip: decrypt the ciphertext, stdout must equal original plaintext
+        dec = _run_main_stdin([*flags, "decrypt", "x.secret"], repo, enc.stdout)
+        assert dec.returncode == 0, dec.stderr
+        assert dec.stdout == b"hello-secret", (flags, dec.stdout[:40])
+```
+
+If `test_main_cli.py` lacks a key-setup path that works offline, gate this test with the same
+mechanism the existing CLI tests use to provide a key (inspect the file first). The invariant under
+test - no flag perturbs `encrypt`/`decrypt` stdout - is the load-bearing assertion.
+
+- [ ] **Step 2: Run**
+
+Run: `poetry run pytest tests/unit/test_main_cli.py -k stdout_is_pure -v`
+Expected: PASS for all four flag sets.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_main_cli.py
+git commit -m "test(cli): guard encrypt/decrypt stdout purity under all output flags"
+```
+
+---
+
+### Task 9: README flag documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a "Output control" section** documenting `--quiet`, `--verbose`, `--json`
+  (with a `status --json` and `doctor --json` example and the note that `--json` is ignored for the
+  git-invoked `encrypt`/`decrypt` filters). Match the README's existing heading style.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document --quiet/--verbose/--json output flags"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `--quiet`/`--verbose`/`--json` flags -> Task 3. Verbose logging -> Task 2. Output layer -> Task 1.
+- stdout-purity carve-out -> exempt paths untouched (Tasks 4-7 never touch `encrypt_stdin`/`decrypt_stdin`); guard-rail -> Task 8.
+- JSON schemas: status -> Task 6, doctor -> Task 7, version -> Task 4, action envelopes -> Task 4, bulk -> Task 5.
+- JSON error contract -> Tasks 4-7 (envelope + nonzero exit / preserved doctor code).
+- Bulk progress -> Task 5. Flag placement (parent parser) -> Task 3. `_print_context` quiet-suppress -> Task 4.
+- Tests enumerated in the spec's Testing section all map to Task steps.
+
+**Type consistency:** `Output(quiet, verbose, json)`, `.info/.error/.progress/.result/.json` used consistently across tasks. `encrypt_files(filter_name, emit=True)` signature matches its `clean_filter` caller. `_envelope_ok/_envelope_err` used identically in Tasks 4-7.
+
+**Known follow-ups (not blocking):** `_require_filter` stays a plain stderr-error+exit even in json mode (no command context pre-dispatch) - documented exception in Task 4.
+

--- a/docs/specs/cli-output-controls/2026-06-22-cli-output-controls-design.md
+++ b/docs/specs/cli-output-controls/2026-06-22-cli-output-controls-design.md
@@ -1,0 +1,191 @@
+# CLI output controls: `--quiet` / `--verbose` / `--json` + bulk progress
+
+Status: approved design
+Date: 2026-06-22
+
+## Goal
+
+Add global output-control flags to the `git-secret-protector` CLI:
+
+- `--quiet` - suppress success/info lines on stdout (errors and exit codes unchanged).
+- `--verbose` - surface internal logs to the terminal (logging is file-only today).
+- `--json` - machine-readable structured output for the report commands, with a
+  uniform result envelope for action commands.
+
+Also add progress feedback for bulk `encrypt-files` / `decrypt-files` over many files.
+
+## Critical constraint: stdout is a binary data channel for `encrypt` / `decrypt`
+
+The `encrypt` and `decrypt` subcommands are git's clean/smudge filters. They write the
+file payload (ciphertext / plaintext bytes) to `sys.stdout.buffer`, and git stores
+whatever lands on stdout as the file content. Any extra byte written to stdout during a
+filter invocation silently corrupts the committed or checked-out file.
+
+Therefore:
+
+- The `encrypt` / `decrypt` (stdin) code path is **exempt** from the output layer.
+  stdout carries data only. Informational messages and errors go to stderr or to logging.
+- `--json`, `--quiet`, `--verbose` do **not** alter `encrypt` / `decrypt` stdout. `--json`
+  is a no-op for these two commands (they are machine-invoked by git, never human-facing).
+- A guard-rail test asserts that `encrypt` / `decrypt` stdout is exactly the expected
+  payload bytes under every flag combination (`--json`, `--quiet`, `--verbose`, none).
+
+This is the single most important invariant of the feature.
+
+## Output modes
+
+Two orthogonal axes, resolved once in `main()` from the parsed flags:
+
+1. Verbosity: `quiet` | `normal` | `verbose`.
+   - `quiet` suppresses info/success lines and bulk progress.
+   - `verbose` attaches a stderr console log handler (INFO/DEBUG) in addition to the
+     existing rotating file handler.
+   - `--quiet` together with `--verbose` is rejected with a clear error (contradictory).
+2. Format: `human` (default) | `json` (`--json`).
+
+Composition rules:
+
+- `--json` implies no human chatter on stdout; the only stdout content is the JSON
+  document. Logs and progress, when enabled, go to stderr - stdout stays pure JSON.
+- `_print_context` (the Backend/Module/Repo-root/Namespace banner, already on stderr) is
+  suppressed under `--quiet`. It never reaches stdout, so it does not affect `--json`.
+
+## Output layer: `core/output.py`
+
+A single `Output` object holds the resolved mode and centralizes routing decisions that
+are currently scattered across `print(...)` / `print(..., file=sys.stderr)` calls.
+
+```
+class Output:
+    def __init__(self, *, quiet=False, verbose=False, json=False): ...
+
+    def info(self, message: str) -> None
+        # human success/info line -> stdout, unless quiet or json
+
+    def error(self, message: str) -> None
+        # error line -> stderr (always; independent of quiet)
+
+    def progress(self, message: str) -> None
+        # progress line -> stderr, unless quiet or json
+
+    def result(self, obj: dict) -> None
+        # json mode: json.dumps(obj) -> stdout
+        # human mode: no-op (human rendering already done via info())
+
+    @property
+    def json(self) -> bool
+```
+
+Configuration and wiring:
+
+- `main()` constructs the `Output` from parsed flags and binds it into the injector
+  (`GitSecretProtectorModule`) before resolving `EncryptionManager`, so the manager
+  receives it by constructor injection. Tests bind a capturing fake the same way.
+- Command methods keep their existing control flow. We do **not** refactor them to
+  "return data, render at the edge" - that fights the existing `print(...); sys.exit(1)`
+  error exits. Instead:
+  - Replace human `print()` calls with `output.info(...)` / `output.error(...)`.
+  - For `status` and `doctor`, build a structured dict during the existing pass and add a
+    localized terminal fork: `if output.json: output.result(dict)` else the human prints.
+
+The `encrypt` / `decrypt` stdin methods do not use `output` for stdout. They may use
+`output.error(...)` (stderr) or logging for diagnostics only.
+
+## JSON schemas
+
+Report commands (rich, stable schemas):
+
+```
+version --json -> {"version": "1.4.0"}
+
+status  --json -> {
+  "repo_root": "/abs/path",
+  "backend": "AWS_SSM",
+  "module_name": "git-secret-protector",
+  "filters": [
+    {"name": "secretfilter",
+     "files": [{"path": "a.secret", "encrypted": true}, ...]}
+  ]
+}
+
+doctor  --json -> {
+  "ok": true,
+  "exit_code": 0,
+  "checks": [
+    {"check": "repository_context", "status": "ok",   "detail": "base_dir=..."},
+    {"check": "config_ini",         "status": "warn", "detail": "not found, defaults in use"},
+    {"check": "filter.secretfilter.git_config", "status": "ok",   "detail": "..."},
+    {"check": "filter.secretfilter.key_cache",  "status": "warn", "detail": "..."},
+    {"check": "backend_credentials", "status": "ok", "detail": "resolved"},
+    {"check": "plaintext_scan.secretfilter", "status": "fail", "detail": "x.secret is PLAINTEXT"}
+  ]
+}
+```
+
+`doctor` `status` values are `ok | warn | fail`. The process still calls `sys.exit` with
+doctor's return code (0 clean, 1 when any tracked secret is plaintext) in both human and
+JSON modes; `exit_code` mirrors that in the object.
+
+Action commands (uniform envelope): `setup-aes-key`, `pull-aes-key`, `rotate-key`,
+`setup-filters`, `clean-filter`, `encrypt-files`, `decrypt-files`.
+
+```
+success -> {"ok": true,  "command": "setup-aes-key", "filter": "x", "message": "..."}
+error   -> {"ok": false, "command": "setup-aes-key", "filter": "x", "error": "..."}
+```
+
+Bulk commands extend the success envelope with counts and per-file results (this data is
+free from the existing loop):
+
+```
+encrypt-files --json -> {
+  "ok": true, "command": "encrypt-files", "filter": "x",
+  "counts": {"encrypted": 3, "skipped": 1, "total": 4},
+  "files": [{"path": "a.secret", "action": "encrypted"},
+            {"path": "b.secret", "action": "skipped"}]
+}
+```
+
+### JSON error contract
+
+In `--json` mode, errors emit the error envelope `{"ok": false, "command", "error", ...}`
+to **stdout** (so a script parsing stdout always gets a document) and the process keeps
+its nonzero exit code. In human mode, errors stay on stderr as today.
+
+## Bulk progress
+
+`encrypt-files` / `decrypt-files` emit `[i/N] <path>` lines via `output.progress(...)`
+(stderr). Suppressed under `--quiet` and under `--json`. No new dependency (no `tqdm`).
+
+## Flag placement
+
+A shared parent parser (`argparse.ArgumentParser(add_help=False)`) defines
+`--quiet`, `--verbose`, `--json`, and `--repo-root`. Each subparser is created with
+`parents=[common]` so the flags read naturally after the subcommand
+(`git-secret-protector status --json`). The flags are also accepted before the subcommand
+for backward compatibility with the existing `--repo-root` placement.
+
+## Affected files
+
+- `src/git_secret_protector/core/output.py` (new) - the `Output` class.
+- `src/git_secret_protector/context/module.py` - bind `Output` in the injector.
+- `src/git_secret_protector/main.py` - parse flags, resolve mode, configure verbose
+  logging, build + bind `Output`, parent parser.
+- `src/git_secret_protector/utils/configure_logging.py` - optional stderr console handler
+  when verbose.
+- `src/git_secret_protector/services/encryption_manager.py` - route human output through
+  `Output`; build structured dicts for `status` / `doctor`; envelopes for action
+  commands; bulk progress. `encrypt`/`decrypt` stdin paths stay stdout-pure.
+
+## Testing
+
+- Guard-rail: `encrypt` / `decrypt` stdout is exact payload bytes under all flag combos.
+- `status --json` / `doctor --json` produce the documented schema; `doctor` exit code
+  preserved in both modes.
+- Action envelope success and error shapes for a representative action command.
+- `--quiet` suppresses info + progress but not errors; exit codes unchanged.
+- `--verbose` adds stderr log output; stdout unaffected.
+- `--quiet --verbose` rejected.
+- Bulk progress counter present in normal mode, absent under `--quiet` / `--json`.
+
+Test command: `poetry run pytest tests/unit/`.

--- a/src/git_secret_protector/context/module.py
+++ b/src/git_secret_protector/context/module.py
@@ -1,15 +1,25 @@
 import injector
 
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
+from git_secret_protector.core.output import Output
 from git_secret_protector.crypto.aes_key_manager import AesKeyManager
 
 
 class GitSecretProtectorModule(injector.Module):
-    _injector: 'injector.Injector' = None
+    _injector = None
+    _output = None
 
     def configure(self, binder):
         binder.bind(AesKeyManager, to=AesKeyManager, scope=injector.singleton)
-        binder.bind(GitAttributesParser, to=GitAttributesParser, scope=injector.singleton)
+        binder.bind(
+            GitAttributesParser, to=GitAttributesParser, scope=injector.singleton
+        )
+        binder.bind(Output, to=self._output or Output(), scope=injector.singleton)
+
+    @classmethod
+    def set_output(cls, output):
+        cls._output = output
+        cls._injector = None  # force rebuild so the binding picks up the instance
 
     @classmethod
     def get_injector(cls):

--- a/src/git_secret_protector/core/output.py
+++ b/src/git_secret_protector/core/output.py
@@ -1,0 +1,39 @@
+# src/git_secret_protector/core/output.py
+import json as _json
+import sys
+
+
+class Output:
+    """Centralized CLI output router. Never used for the encrypt/decrypt
+    filter path, whose stdout carries binary file payload."""
+
+    def __init__(self, quiet=False, verbose=False, json=False):
+        self._quiet = quiet
+        self._verbose = verbose
+        self._json = json
+
+    @property
+    def json(self):
+        return self._json
+
+    @property
+    def verbose(self):
+        return self._verbose
+
+    def info(self, message):
+        if self._quiet or self._json:
+            return
+        print(message)
+
+    def error(self, message):
+        print(message, file=sys.stderr)
+
+    def progress(self, message):
+        if self._quiet or self._json:
+            return
+        print(message, file=sys.stderr)
+
+    def result(self, obj):
+        if not self._json:
+            return
+        print(_json.dumps(obj), file=sys.stdout)

--- a/src/git_secret_protector/core/output.py
+++ b/src/git_secret_protector/core/output.py
@@ -20,6 +20,10 @@ class Output:
     def verbose(self):
         return self._verbose
 
+    @property
+    def quiet(self):
+        return self._quiet
+
     def info(self, message):
         if self._quiet or self._json:
             return

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -275,7 +275,6 @@ def main():
     output = Output(
         quiet=getattr(args, "quiet", False),
         verbose=getattr(args, "verbose", False),
-        # --json is accepted both before and after the subcommand; OR the two values
         json=getattr(args, "json", False),
     )
 

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -119,44 +119,35 @@ def show_project_version(args, output=None):
 
 
 def main():
-    # Parent with global flags that appear BEFORE the subcommand.
-    # --repo-root/--quiet/--verbose live here only so subparser defaults
-    # don't shadow the top-level parsed value.
-    global_flags = argparse.ArgumentParser(add_help=False)
-    global_flags.add_argument(
+    # Shared parent inherited by both the top-level parser and every subparser.
+    # SUPPRESS means an absent flag sets NO attribute, so a subparser parse
+    # cannot clobber a value already captured by the top-level parse.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
         "--repo-root",
         type=str,
-        default=None,
+        default=argparse.SUPPRESS,
         help=(
             "Repo root to operate on (overrides auto-detection; same as the "
-            "SECRET_PROTECTOR_BASE_DIR env var). Must precede the subcommand."
+            "SECRET_PROTECTOR_BASE_DIR env var)."
         ),
     )
-    global_flags.add_argument(
+    common.add_argument(
         "--quiet",
         action="store_true",
+        default=argparse.SUPPRESS,
         help="Suppress success/info output (errors still shown).",
     )
-    global_flags.add_argument(
+    common.add_argument(
         "--verbose",
         action="store_true",
+        default=argparse.SUPPRESS,
         help="Show internal logs on stderr.",
     )
-    global_flags.add_argument(
+    common.add_argument(
         "--json",
         action="store_true",
-        help=(
-            "Emit machine-readable JSON (status/doctor/version and "
-            "action results; ignored for encrypt/decrypt)."
-        ),
-    )
-
-    # Parent with --json only, inherited by subparsers so the flag is also
-    # accepted AFTER the subcommand (e.g. `status --json`).
-    json_flag = argparse.ArgumentParser(add_help=False)
-    json_flag.add_argument(
-        "--json",
-        action="store_true",
+        default=argparse.SUPPRESS,
         help=(
             "Emit machine-readable JSON (status/doctor/version and "
             "action results; ignored for encrypt/decrypt)."
@@ -179,7 +170,7 @@ def main():
             "git-secret-protector setup-filters"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        parents=[global_flags],
+        parents=[common],
     )
     parser.add_argument(
         "-V",
@@ -210,13 +201,13 @@ def main():
     parser_setup_filters_stdin = subparsers.add_parser(
         "setup-filters",
         help="Set up Git filters in Git config",
-        parents=[json_flag],
+        parents=[common],
     )
     parser_setup_filters_stdin.set_defaults(func=setup_filters)
 
     # Command to decrypt data from stdin
     parser_decrypt_stdin = subparsers.add_parser(
-        "decrypt", help="Decrypt data from stdin", parents=[json_flag]
+        "decrypt", help="Decrypt data from stdin", parents=[common]
     )
     parser_decrypt_stdin.add_argument(
         "file_name", type=str, help="Filename for decryption"
@@ -225,7 +216,7 @@ def main():
 
     # Command to encrypt data from stdin
     parser_encrypt_stdin = subparsers.add_parser(
-        "encrypt", help="Encrypt data from stdin", parents=[json_flag]
+        "encrypt", help="Encrypt data from stdin", parents=[common]
     )
     parser_encrypt_stdin.add_argument(
         "file_name", type=str, help="Filename for encryption"
@@ -233,9 +224,7 @@ def main():
     parser_encrypt_stdin.set_defaults(func=encrypt_stdin)
 
     for cmd_name, func, help_text in filter_commands:
-        parser_cmd = subparsers.add_parser(
-            cmd_name, help=help_text, parents=[json_flag]
-        )
+        parser_cmd = subparsers.add_parser(cmd_name, help=help_text, parents=[common])
         parser_cmd.add_argument(
             "filter_name", type=str, nargs="?", help="The filter name"
         )
@@ -244,7 +233,7 @@ def main():
     parser_rotate_key = subparsers.add_parser(
         "rotate-key",
         help="Rotate AES key and re-encrypt secrets",
-        parents=[json_flag],
+        parents=[common],
     )
     parser_rotate_key.add_argument(
         "filter_name", type=str, nargs="?", help="The filter name"
@@ -259,18 +248,18 @@ def main():
 
     # Status command
     parser_status = subparsers.add_parser(
-        "status", help="List all filters and file statuses", parents=[json_flag]
+        "status", help="List all filters and file statuses", parents=[common]
     )
     parser_status.set_defaults(func=status_command)
 
     parser_doctor = subparsers.add_parser(
-        "doctor", help="Diagnose the git-secret-protector setup", parents=[json_flag]
+        "doctor", help="Diagnose the git-secret-protector setup", parents=[common]
     )
     parser_doctor.set_defaults(func=doctor_command)
 
     # Version command
     parser_version = subparsers.add_parser(
-        "version", help="Show version", parents=[json_flag]
+        "version", help="Show version", parents=[common]
     )
     parser_version.set_defaults(func=show_project_version)
 
@@ -292,11 +281,11 @@ def main():
 
     try:
         if args.func is not show_project_version:
-            if args.repo_root:
+            if getattr(args, "repo_root", None):
                 repo_root = Path(args.repo_root).resolve()
                 if not repo_root.is_dir():
                     print(
-                        f"Error: --repo-root points to a missing directory: {args.repo_root}",
+                        f"Error: --repo-root points to a missing directory: {getattr(args, 'repo_root', '')}",
                         file=sys.stderr,
                     )
                     sys.exit(1)

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from git_secret_protector.context.module import GitSecretProtectorModule
+from git_secret_protector.core.output import Output
 from git_secret_protector.core.settings import Settings, get_settings
 from git_secret_protector.services.encryption_manager import EncryptionManager
 from git_secret_protector.utils.configure_logging import configure_logging
@@ -113,11 +114,55 @@ def doctor_command(_):
     sys.exit(manager.doctor())
 
 
-def show_project_version(_):
-    EncryptionManager.show_project_version()
+def show_project_version(args, output=None):
+    EncryptionManager.show_project_version(args, output)
 
 
 def main():
+    # Parent with global flags that appear BEFORE the subcommand.
+    # --repo-root/--quiet/--verbose live here only so subparser defaults
+    # don't shadow the top-level parsed value.
+    global_flags = argparse.ArgumentParser(add_help=False)
+    global_flags.add_argument(
+        "--repo-root",
+        type=str,
+        default=None,
+        help=(
+            "Repo root to operate on (overrides auto-detection; same as the "
+            "SECRET_PROTECTOR_BASE_DIR env var). Must precede the subcommand."
+        ),
+    )
+    global_flags.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress success/info output (errors still shown).",
+    )
+    global_flags.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show internal logs on stderr.",
+    )
+    global_flags.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit machine-readable JSON (status/doctor/version and "
+            "action results; ignored for encrypt/decrypt)."
+        ),
+    )
+
+    # Parent with --json only, inherited by subparsers so the flag is also
+    # accepted AFTER the subcommand (e.g. `status --json`).
+    json_flag = argparse.ArgumentParser(add_help=False)
+    json_flag.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit machine-readable JSON (status/doctor/version and "
+            "action results; ignored for encrypt/decrypt)."
+        ),
+    )
+
     parser = argparse.ArgumentParser(
         description=(
             "Encrypt selected repository files transparently with Git filters and "
@@ -128,27 +173,19 @@ def main():
             "  1. create .gitattributes mapping globs to filters\n"
             "  2. git-secret-protector setup-filters\n"
             "  3. git-secret-protector setup-aes-key <filter>\n"
-            "  4. edit/commit — files are encrypted transparently\n"
+            "  4. edit/commit - files are encrypted transparently\n"
             "Team member:\n"
             "  git-secret-protector pull-aes-key <filter> && "
             "git-secret-protector setup-filters"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[global_flags],
     )
     parser.add_argument(
         "-V",
         "--version",
         action="version",
         version=f"git-secret-protector {_safe_version()}",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=str,
-        default=None,
-        help=(
-            "Repo root to operate on (overrides auto-detection; same as the "
-            "SECRET_PROTECTOR_BASE_DIR env var). Must precede the subcommand."
-        ),
     )
     subparsers = parser.add_subparsers(help="Available commands")
 
@@ -171,13 +208,15 @@ def main():
 
     # Command to set up Git filters
     parser_setup_filters_stdin = subparsers.add_parser(
-        "setup-filters", help="Set up Git filters in Git config"
+        "setup-filters",
+        help="Set up Git filters in Git config",
+        parents=[json_flag],
     )
     parser_setup_filters_stdin.set_defaults(func=setup_filters)
 
     # Command to decrypt data from stdin
     parser_decrypt_stdin = subparsers.add_parser(
-        "decrypt", help="Decrypt data from stdin"
+        "decrypt", help="Decrypt data from stdin", parents=[json_flag]
     )
     parser_decrypt_stdin.add_argument(
         "file_name", type=str, help="Filename for decryption"
@@ -186,7 +225,7 @@ def main():
 
     # Command to encrypt data from stdin
     parser_encrypt_stdin = subparsers.add_parser(
-        "encrypt", help="Encrypt data from stdin"
+        "encrypt", help="Encrypt data from stdin", parents=[json_flag]
     )
     parser_encrypt_stdin.add_argument(
         "file_name", type=str, help="Filename for encryption"
@@ -194,14 +233,18 @@ def main():
     parser_encrypt_stdin.set_defaults(func=encrypt_stdin)
 
     for cmd_name, func, help_text in filter_commands:
-        parser_cmd = subparsers.add_parser(cmd_name, help=help_text)
+        parser_cmd = subparsers.add_parser(
+            cmd_name, help=help_text, parents=[json_flag]
+        )
         parser_cmd.add_argument(
             "filter_name", type=str, nargs="?", help="The filter name"
         )
         parser_cmd.set_defaults(func=func)
 
     parser_rotate_key = subparsers.add_parser(
-        "rotate-key", help="Rotate AES key and re-encrypt secrets"
+        "rotate-key",
+        help="Rotate AES key and re-encrypt secrets",
+        parents=[json_flag],
     )
     parser_rotate_key.add_argument(
         "filter_name", type=str, nargs="?", help="The filter name"
@@ -216,43 +259,60 @@ def main():
 
     # Status command
     parser_status = subparsers.add_parser(
-        "status", help="List all filters and file statuses"
+        "status", help="List all filters and file statuses", parents=[json_flag]
     )
     parser_status.set_defaults(func=status_command)
 
     parser_doctor = subparsers.add_parser(
-        "doctor", help="Diagnose the git-secret-protector setup"
+        "doctor", help="Diagnose the git-secret-protector setup", parents=[json_flag]
     )
     parser_doctor.set_defaults(func=doctor_command)
 
     # Version command
-    parser_status = subparsers.add_parser("version", help="Show version")
-    parser_status.set_defaults(func=show_project_version)
+    parser_version = subparsers.add_parser(
+        "version", help="Show version", parents=[json_flag]
+    )
+    parser_version.set_defaults(func=show_project_version)
 
     args = parser.parse_args()
-    if hasattr(args, "func"):
-        try:
-            if args.func is not show_project_version:
-                if args.repo_root:
-                    repo_root = Path(args.repo_root).resolve()
-                    if not repo_root.is_dir():
-                        print(
-                            f"Error: --repo-root points to a missing directory: {args.repo_root}",
-                            file=sys.stderr,
-                        )
-                        sys.exit(1)
-                    os.environ[Settings.BASE_DIR_ENV_VAR] = str(repo_root)
-                    os.chdir(repo_root)
-                init_module_folder()
-                configure_logging()
-                global manager
-                manager = GitSecretProtectorModule.get_injector().get(EncryptionManager)
-            args.func(args)
-        except FileNotFoundError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            sys.exit(1)
-    else:
+    if not hasattr(args, "func"):
         parser.print_help()
+        return
+
+    if getattr(args, "quiet", False) and getattr(args, "verbose", False):
+        print("Error: --quiet and --verbose are mutually exclusive.", file=sys.stderr)
+        sys.exit(2)
+
+    output = Output(
+        quiet=getattr(args, "quiet", False),
+        verbose=getattr(args, "verbose", False),
+        # --json is accepted both before and after the subcommand; OR the two values
+        json=getattr(args, "json", False),
+    )
+
+    try:
+        if args.func is not show_project_version:
+            if args.repo_root:
+                repo_root = Path(args.repo_root).resolve()
+                if not repo_root.is_dir():
+                    print(
+                        f"Error: --repo-root points to a missing directory: {args.repo_root}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                os.environ[Settings.BASE_DIR_ENV_VAR] = str(repo_root)
+                os.chdir(repo_root)
+            init_module_folder()
+            configure_logging(verbose=output.verbose)
+            GitSecretProtectorModule.set_output(output)
+            global manager
+            manager = GitSecretProtectorModule.get_injector().get(EncryptionManager)
+            args.func(args)
+        else:
+            show_project_version(args, output)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -416,16 +416,35 @@ class EncryptionManager:
     def doctor(self) -> int:
         settings = get_settings()
         failed = False
+        checks = []
 
-        print("[ OK ] Repository context")
-        print(f"  base_dir: {settings.base_dir}")
-        print(f"  backend: {settings.storage_type.value}")
-        print(f"  module_name: {settings.module_name}")
+        # Repository context - stored as a special multi-line block in detail
+        repo_lines = (
+            f"Repository context\n"
+            f"  base_dir: {settings.base_dir}\n"
+            f"  backend: {settings.storage_type.value}\n"
+            f"  module_name: {settings.module_name}"
+        )
+        checks.append(
+            {"check": "repository_context", "status": "ok", "detail": repo_lines}
+        )
 
         if os.path.exists(settings.config_file):
-            print(f"[ OK ] config.ini found at {settings.config_file}")
+            checks.append(
+                {
+                    "check": "config_ini",
+                    "status": "ok",
+                    "detail": f"config.ini found at {settings.config_file}",
+                }
+            )
         else:
-            print("[WARN] config.ini not found (defaults in use)")
+            checks.append(
+                {
+                    "check": "config_ini",
+                    "status": "warn",
+                    "detail": "config.ini not found (defaults in use)",
+                }
+            )
 
         filter_names = []
         try:
@@ -434,10 +453,24 @@ class EncryptionManager:
             pass
 
         if not filter_names:
-            print("[WARN] no filters defined in .gitattributes")
-            return 1 if failed else 0
+            checks.append(
+                {
+                    "check": "filters_declared",
+                    "status": "warn",
+                    "detail": "no filters defined in .gitattributes",
+                }
+            )
+            exit_code = 1 if failed else 0
+            self._doctor_emit(checks, failed, exit_code)
+            return exit_code
 
-        print(f"[ OK ] filters declared: {', '.join(filter_names)}")
+        checks.append(
+            {
+                "check": "filters_declared",
+                "status": "ok",
+                "detail": f"filters declared: {', '.join(filter_names)}",
+            }
+        )
 
         for filter_name in filter_names:
             check_clean = subprocess.run(
@@ -452,17 +485,37 @@ class EncryptionManager:
             ).stdout.strip()
 
             if check_clean and check_smudge:
-                print(f"[ OK ] filter '{filter_name}' configured in .git/config")
+                checks.append(
+                    {
+                        "check": "git_config",
+                        "status": "ok",
+                        "detail": f"filter '{filter_name}' configured in .git/config",
+                    }
+                )
             else:
-                print(
-                    f"[WARN] filter '{filter_name}' not configured in .git/config (run setup-filters)"
+                checks.append(
+                    {
+                        "check": "git_config",
+                        "status": "warn",
+                        "detail": f"filter '{filter_name}' not configured in .git/config (run setup-filters)",
+                    }
                 )
 
             if self.key_manager.is_cached(filter_name):
-                print(f"[ OK ] local key cache exists for '{filter_name}'")
+                checks.append(
+                    {
+                        "check": "key_cache",
+                        "status": "ok",
+                        "detail": f"local key cache exists for '{filter_name}'",
+                    }
+                )
             else:
-                print(
-                    f"[WARN] no local key cache for '{filter_name}' (run pull-aes-key)"
+                checks.append(
+                    {
+                        "check": "key_cache",
+                        "status": "warn",
+                        "detail": f"no local key cache for '{filter_name}' (run pull-aes-key)",
+                    }
                 )
 
         # Resolving the parameter name forces credential/region resolution
@@ -470,9 +523,21 @@ class EncryptionManager:
         # not that the key parameter exists or that a full fetch would succeed.
         try:
             self.key_manager.resolve_parameter_name(filter_names[0])
-            print("[ OK ] backend credentials/region resolved")
+            checks.append(
+                {
+                    "check": "backend_credentials",
+                    "status": "ok",
+                    "detail": "backend credentials/region resolved",
+                }
+            )
         except Exception:
-            print("[WARN] backend credentials/region unresolved (offline ok)")
+            checks.append(
+                {
+                    "check": "backend_credentials",
+                    "status": "warn",
+                    "detail": "backend credentials/region unresolved (offline ok)",
+                }
+            )
 
         for filter_name in filter_names:
             files = self.git_attributes_parser.get_files_for_filter(filter_name)
@@ -482,16 +547,47 @@ class EncryptionManager:
                 if not self.__is_encrypted(file_path):
                     plaintext_files.append(file_path)
                     failed = True
-                    print(
-                        f"[FAIL] {file_path} is tracked as secret but is PLAINTEXT in the working tree"
+                    checks.append(
+                        {
+                            "check": "plaintext_scan",
+                            "status": "fail",
+                            "detail": f"{file_path} is tracked as secret but is PLAINTEXT in the working tree",
+                        }
                     )
 
             if not plaintext_files:
-                print(
-                    f"[ OK ] all tracked secret files are encrypted for '{filter_name}'"
+                checks.append(
+                    {
+                        "check": "plaintext_scan",
+                        "status": "ok",
+                        "detail": f"all tracked secret files are encrypted for '{filter_name}'",
+                    }
                 )
 
-        return 1 if failed else 0
+        exit_code = 1 if failed else 0
+        self._doctor_emit(checks, failed, exit_code)
+        return exit_code
+
+    def _doctor_emit(self, checks, failed, exit_code):
+        if self.output.json:
+            self.output.result(
+                {"ok": not failed, "exit_code": exit_code, "checks": checks}
+            )
+            return
+        # Human mode: render each check with its label; repository_context gets
+        # its first line as the label target and sub-lines printed as-is.
+        label_map = {"ok": "[ OK ]", "warn": "[WARN]", "fail": "[FAIL]"}
+        for c in checks:
+            label = label_map[c["status"]]
+            detail = c["detail"]
+            if c["check"] == "repository_context":
+                # detail is "Repository context\n  line2\n  line3\n  line4"
+                lines = detail.split("\n")
+                print(f"{label} {lines[0]}")
+                for sub in lines[1:]:
+                    print(sub)
+            else:
+                print(f"{label} {detail}")
 
     @staticmethod
     def show_project_version(_=None, output=None):

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -39,7 +39,7 @@ class EncryptionManager:
         return {"ok": False, "command": command, "error": error, **fields}
 
     def _print_context(self, filter_name=None):
-        if self.output._quiet:
+        if self.output.quiet:
             return
         settings = get_settings()
         self.output.error(f"Backend:   {settings.storage_type.value}")
@@ -490,6 +490,7 @@ class EncryptionManager:
                         "check": "git_config",
                         "status": "ok",
                         "detail": f"filter '{filter_name}' configured in .git/config",
+                        "filter": filter_name,
                     }
                 )
             else:
@@ -498,6 +499,7 @@ class EncryptionManager:
                         "check": "git_config",
                         "status": "warn",
                         "detail": f"filter '{filter_name}' not configured in .git/config (run setup-filters)",
+                        "filter": filter_name,
                     }
                 )
 
@@ -507,6 +509,7 @@ class EncryptionManager:
                         "check": "key_cache",
                         "status": "ok",
                         "detail": f"local key cache exists for '{filter_name}'",
+                        "filter": filter_name,
                     }
                 )
             else:
@@ -515,6 +518,7 @@ class EncryptionManager:
                         "check": "key_cache",
                         "status": "warn",
                         "detail": f"no local key cache for '{filter_name}' (run pull-aes-key)",
+                        "filter": filter_name,
                     }
                 )
 
@@ -552,6 +556,7 @@ class EncryptionManager:
                             "check": "plaintext_scan",
                             "status": "fail",
                             "detail": f"{file_path} is tracked as secret but is PLAINTEXT in the working tree",
+                            "filter": filter_name,
                         }
                     )
 
@@ -561,6 +566,7 @@ class EncryptionManager:
                         "check": "plaintext_scan",
                         "status": "ok",
                         "detail": f"all tracked secret files are encrypted for '{filter_name}'",
+                        "filter": filter_name,
                     }
                 )
 

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import injector
 
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
+from git_secret_protector.core.output import Output
 from git_secret_protector.core.settings import get_settings
 from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
 from git_secret_protector.crypto.aes_key_manager import AesKeyManager
@@ -23,22 +24,32 @@ class EncryptionManager:
         git_attributes_parser: GitAttributesParser,
         key_manager: AesKeyManager,
         key_rotator: KeyRotator,
+        output: Output = None,
     ):
         self.git_attributes_parser = git_attributes_parser
         self.key_manager = key_manager
         self.key_rotator = key_rotator
+        self.output = output if output is not None else Output()
         self.magic_header = get_settings().magic_header.encode()
 
+    def _envelope_ok(self, command, **fields):
+        return {"ok": True, "command": command, **fields}
+
+    def _envelope_err(self, command, error, **fields):
+        return {"ok": False, "command": command, "error": error, **fields}
+
     def _print_context(self, filter_name=None):
+        if self.output._quiet:
+            return
         settings = get_settings()
-        print(f"Backend:   {settings.storage_type.value}", file=sys.stderr)
-        print(f"Module:    {settings.module_name}", file=sys.stderr)
-        print(f"Repo root: {settings.base_dir}", file=sys.stderr)
+        self.output.error(f"Backend:   {settings.storage_type.value}")
+        self.output.error(f"Module:    {settings.module_name}")
+        self.output.error(f"Repo root: {settings.base_dir}")
 
         if filter_name is not None:
             try:
                 path = self.key_manager.resolve_parameter_name(filter_name)
-                print(f"Namespace: {path}", file=sys.stderr)
+                self.output.error(f"Namespace: {path}")
             except Exception:
                 pass
 
@@ -58,7 +69,7 @@ class EncryptionManager:
                 "a filter name is required. No filters defined "
                 "(.gitattributes missing or empty)."
             )
-        print(f"Error: {msg}", file=sys.stderr)
+        self.output.error(f"Error: {msg}")
         sys.exit(1)
 
     def setup_aes_key(self, filter_name: str):
@@ -68,10 +79,17 @@ class EncryptionManager:
             logger.info("Setting up AES key for filter: %s", filter_name)
             self.key_manager.setup_aes_key_and_iv(filter_name)
             logger.info("Successfully set up AES key for filter: %s", filter_name)
-            print(f"Successfully set up AES key for filter: {filter_name}")
+            msg = f"Successfully set up AES key for filter: {filter_name}"
+            self.output.info(msg)
+            self.output.result(
+                self._envelope_ok("setup-aes-key", filter=filter_name, message=msg)
+            )
         except Exception as e:
             logger.error(f"AES key setup command failed: {e}", exc_info=True)
-            print(f"AES key setup command failed: {e}", file=sys.stderr)
+            self.output.error(f"AES key setup command failed: {e}")
+            self.output.result(
+                self._envelope_err("setup-aes-key", str(e), filter=filter_name)
+            )
             sys.exit(1)
 
     def setup_filters(self):
@@ -80,7 +98,9 @@ class EncryptionManager:
         for filter_name in filter_names:
             self.__init_filter(filter_name=filter_name)
         logger.info("Successfully set up filters")
-        print("Successfully set up filters")
+        msg = "Successfully set up filters"
+        self.output.info(msg)
+        self.output.result(self._envelope_ok("setup-filters", message=msg))
 
     def pull_aes_key(self, filter_name: str):
         filter_name = self._require_filter(filter_name)
@@ -89,10 +109,17 @@ class EncryptionManager:
             logger.info("Pulling AES key for filter: %s", filter_name)
             self.key_manager.retrieve_key_and_iv(filter_name=filter_name)
             logger.info("Successfully pulled AES key for filter: %s", filter_name)
-            print(f"Successfully pulled AES key for filter: {filter_name}")
+            msg = f"Successfully pulled AES key for filter: {filter_name}"
+            self.output.info(msg)
+            self.output.result(
+                self._envelope_ok("pull-aes-key", filter=filter_name, message=msg)
+            )
         except Exception as e:
             logger.error(f"Pull AES key command failed: {e}", exc_info=True)
-            print(f"Pull AES key command failed: {e}", file=sys.stderr)
+            self.output.error(f"Pull AES key command failed: {e}")
+            self.output.result(
+                self._envelope_err("pull-aes-key", str(e), filter=filter_name)
+            )
             sys.exit(1)
 
     def encrypt_files(self, filter_name: str):
@@ -110,10 +137,17 @@ class EncryptionManager:
                 files=files_to_encrypt
             )
             logging.info(f"Successfully encrypted files for filter: {filter_name}")
-            print(f"Successfully encrypted files for filter: {filter_name}")
+            msg = f"Successfully encrypted files for filter: {filter_name}"
+            self.output.info(msg)
+            self.output.result(
+                self._envelope_ok("encrypt-files", filter=filter_name, message=msg)
+            )
         except Exception as e:
             logger.error(f"Encrypt files command failed: {e}", exc_info=True)
-            print(f"Encrypt files command failed: {str(e)}", file=sys.stderr)
+            self.output.error(f"Encrypt files command failed: {str(e)}")
+            self.output.result(
+                self._envelope_err("encrypt-files", str(e), filter=filter_name)
+            )
             sys.exit(1)
 
     def decrypt_files(self, filter_name: str):
@@ -131,10 +165,17 @@ class EncryptionManager:
                 files=files_to_decrypt
             )
             logging.info(f"Successfully decrypted files for filter: {filter_name}")
-            print(f"Successfully decrypted files for filter: {filter_name}")
+            msg = f"Successfully decrypted files for filter: {filter_name}"
+            self.output.info(msg)
+            self.output.result(
+                self._envelope_ok("decrypt-files", filter=filter_name, message=msg)
+            )
         except Exception as e:
             logger.error(f"Decrypt files command failed: {e}", exc_info=True)
-            print(f"Decrypt files command failed: {e}", file=sys.stderr)
+            self.output.error(f"Decrypt files command failed: {e}")
+            self.output.result(
+                self._envelope_err("decrypt-files", str(e), filter=filter_name)
+            )
             sys.exit(1)
 
     def encrypt_stdin(self, file_name):
@@ -209,22 +250,36 @@ class EncryptionManager:
                         f"Rotate key for filter '{filter_name}'? This re-encrypts ALL matched files and retires the current key. [y/N] "
                     )
                 except EOFError:
-                    # No TTY (CI / piped stdin) and no explicit consent — treat as
+                    # No TTY (CI / piped stdin) and no explicit consent - treat as
                     # a decline so a destructive rotation never runs unconfirmed.
                     answer = ""
                 if answer.strip().lower() not in {"y", "yes"}:
-                    print(
-                        "Aborted (no confirmation; pass -y/--yes for non-interactive use).",
-                        file=sys.stderr,
+                    self.output.error(
+                        "Aborted (no confirmation; pass -y/--yes for non-interactive use)."
+                    )
+                    self.output.result(
+                        self._envelope_ok(
+                            "rotate-key",
+                            filter=filter_name,
+                            message="aborted",
+                            ok=False,
+                        )
                     )
                     return
             rotator = KeyRotator(self.key_manager, self.git_attributes_parser)
             rotator.rotate_key(filter_name)
             logger.info("Key rotation complete for filter: %s", filter_name)
-            print(f"Key rotation complete for filter: {filter_name}")
+            msg = f"Key rotation complete for filter: {filter_name}"
+            self.output.info(msg)
+            self.output.result(
+                self._envelope_ok("rotate-key", filter=filter_name, message=msg)
+            )
         except Exception as e:
             logger.error(f"Rotate keys command failed: {e}", exc_info=True)
-            print(f"Rotate keys command failed: {e}", file=sys.stderr)
+            self.output.error(f"Rotate keys command failed: {e}")
+            self.output.result(
+                self._envelope_err("rotate-key", str(e), filter=filter_name)
+            )
             sys.exit(1)
 
     def clean_filter(self, filter_name: str):
@@ -241,10 +296,17 @@ class EncryptionManager:
 
             self.key_manager.remove_key_iv_from_cache(filter_name=filter_name)
             logger.info("Successfully cleaned staged data for filter: %s", filter_name)
-            print(f"Successfully cleaned staged data for filter: {filter_name}")
+            msg = f"Successfully cleaned staged data for filter: {filter_name}"
+            self.output.info(msg)
+            self.output.result(
+                self._envelope_ok("clean-filter", filter=filter_name, message=msg)
+            )
         except Exception as e:
             logger.error(f"Clean filter command failed: {e}", exc_info=True)
-            print(f"Clean filter command failed: {e}", file=sys.stderr)
+            self.output.error(f"Clean filter command failed: {e}")
+            self.output.result(
+                self._envelope_err("clean-filter", str(e), filter=filter_name)
+            )
             sys.exit(1)
 
     def status(self):
@@ -252,17 +314,18 @@ class EncryptionManager:
         try:
             filter_names = self.git_attributes_parser.get_filter_names()
             for filter_name in filter_names:
-                print(f"Filter: {filter_name}")
+                self.output.info(f"Filter: {filter_name}")
                 files = self.git_attributes_parser.get_files_for_filter(filter_name)
                 if files:
                     for file in files:
                         encrypted = self.__is_encrypted(file_path=file)
                         status = "Encrypted" if encrypted else "⚠ PLAINTEXT"
-                        print(f"  {file}: {status}")
+                        self.output.info(f"  {file}: {status}")
                 else:
-                    print("  No files found for this filter.")
+                    self.output.info("  No files found for this filter.")
+            self.output.result(self._envelope_ok("status"))
         except Exception as e:
-            print(f"Status command failed: {e}", file=sys.stderr)
+            self.output.error(f"Status command failed: {e}")
             sys.exit(1)
 
     def doctor(self) -> int:
@@ -346,13 +409,16 @@ class EncryptionManager:
         return 1 if failed else 0
 
     @staticmethod
-    def show_project_version():
+    def show_project_version(_=None, output=None):
+        output = output if output is not None else Output()
         try:
             version = get_project_version_from_metadata()
-            print(f"git-secret-protector version: {version}")
+            output.info(f"git-secret-protector version: {version}")
+            output.result({"version": version})
         except Exception as e:
             logger.error(f"Failed to get project version: {e}", exc_info=True)
-            print(f"Failed to get project version: {str(e)}", file=sys.stderr)
+            output.error(f"Failed to get project version: {str(e)}")
+            output.result({"ok": False, "command": "version", "error": str(e)})
 
     @staticmethod
     def _get_poetry_root_path():

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -93,14 +93,20 @@ class EncryptionManager:
             sys.exit(1)
 
     def setup_filters(self):
-        logger.info("Setting up filters")
-        filter_names = self.git_attributes_parser.get_filter_names()
-        for filter_name in filter_names:
-            self.__init_filter(filter_name=filter_name)
-        logger.info("Successfully set up filters")
-        msg = "Successfully set up filters"
-        self.output.info(msg)
-        self.output.result(self._envelope_ok("setup-filters", message=msg))
+        try:
+            logger.info("Setting up filters")
+            filter_names = self.git_attributes_parser.get_filter_names()
+            for filter_name in filter_names:
+                self.__init_filter(filter_name=filter_name)
+            logger.info("Successfully set up filters")
+            msg = "Successfully set up filters"
+            self.output.info(msg)
+            self.output.result(self._envelope_ok("setup-filters", message=msg))
+        except Exception as e:
+            logger.error(f"Setup filters command failed: {e}", exc_info=True)
+            self.output.error(f"Setup filters command failed: {e}")
+            self.output.result(self._envelope_err("setup-filters", str(e)))
+            sys.exit(1)
 
     def pull_aes_key(self, filter_name: str):
         filter_name = self._require_filter(filter_name)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -378,20 +378,39 @@ class EncryptionManager:
     def status(self):
         self._print_context()
         try:
+            settings = get_settings()
             filter_names = self.git_attributes_parser.get_filter_names()
+            data = {
+                "repo_root": settings.base_dir,
+                "backend": settings.storage_type.value,
+                "module_name": settings.module_name,
+                "filters": [],
+            }
             for filter_name in filter_names:
-                self.output.info(f"Filter: {filter_name}")
                 files = self.git_attributes_parser.get_files_for_filter(filter_name)
-                if files:
-                    for file in files:
-                        encrypted = self.__is_encrypted(file_path=file)
-                        status = "Encrypted" if encrypted else "⚠ PLAINTEXT"
-                        self.output.info(f"  {file}: {status}")
+                file_entries = [
+                    {"path": f, "encrypted": self.__is_encrypted(file_path=f)}
+                    for f in files
+                ]
+                data["filters"].append({"name": filter_name, "files": file_entries})
+
+            if self.output.json:
+                self.output.result(data)
+                return
+
+            for entry in data["filters"]:
+                print(f"Filter: {entry['name']}")
+                if entry["files"]:
+                    for f in entry["files"]:
+                        status = "Encrypted" if f["encrypted"] else "⚠ PLAINTEXT"
+                        print(f"  {f['path']}: {status}")
                 else:
-                    self.output.info("  No files found for this filter.")
-            self.output.result(self._envelope_ok("status"))
+                    print("  No files found for this filter.")
         except Exception as e:
-            self.output.error(f"Status command failed: {e}")
+            if self.output.json:
+                self.output.result(self._envelope_err("status", str(e)))
+            else:
+                self.output.error(f"Status command failed: {e}")
             sys.exit(1)
 
     def doctor(self) -> int:

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -128,60 +128,120 @@ class EncryptionManager:
             )
             sys.exit(1)
 
-    def encrypt_files(self, filter_name: str):
+    def encrypt_files(self, filter_name: str, emit: bool = True):
         filter_name = self._require_filter(filter_name)
         try:
             logger.info("Encrypting files for filter: %s", filter_name)
-            files_to_encrypt = self.git_attributes_parser.get_files_for_filter(
+            files = self.git_attributes_parser.get_files_for_filter(
                 filter_name=filter_name
             )
-            if not files_to_encrypt:
+            if not files:
                 logging.info(f"No files to encrypt for filter: {filter_name}")
-                return
+                if emit:
+                    msg = f"No files to encrypt for filter: {filter_name}"
+                    self.output.info(msg)
+                    self.output.result(
+                        self._envelope_ok(
+                            "encrypt-files",
+                            filter=filter_name,
+                            counts={"encrypted": 0, "skipped": 0, "total": 0},
+                            files=[],
+                            message=msg,
+                        )
+                    )
+                return {"encrypted": 0, "skipped": 0, "total": 0}
 
-            self.__get_encryption_handler(filter_name=filter_name).encrypt_files(
-                files=files_to_encrypt
-            )
+            handler = self.__get_encryption_handler(filter_name=filter_name)
+            total = len(files)
+            results = []
+            counts = {"encrypted": 0, "skipped": 0, "total": total}
+            for i, file in enumerate(files, 1):
+                self.output.progress(f"[{i}/{total}] {file}")
+                was_encrypted = self.__is_encrypted(file_path=file)
+                handler.encrypt_file(file)
+                action = "skipped" if was_encrypted else "encrypted"
+                counts[action] += 1
+                results.append({"path": file, "action": action})
+
             logging.info(f"Successfully encrypted files for filter: {filter_name}")
-            msg = f"Successfully encrypted files for filter: {filter_name}"
-            self.output.info(msg)
-            self.output.result(
-                self._envelope_ok("encrypt-files", filter=filter_name, message=msg)
-            )
+            if emit:
+                msg = f"Successfully encrypted files for filter: {filter_name}"
+                self.output.info(msg)
+                self.output.result(
+                    self._envelope_ok(
+                        "encrypt-files",
+                        filter=filter_name,
+                        counts=counts,
+                        files=results,
+                        message=msg,
+                    )
+                )
+            return counts
         except Exception as e:
             logger.error(f"Encrypt files command failed: {e}", exc_info=True)
             self.output.error(f"Encrypt files command failed: {str(e)}")
-            self.output.result(
-                self._envelope_err("encrypt-files", str(e), filter=filter_name)
-            )
+            if emit:
+                self.output.result(
+                    self._envelope_err("encrypt-files", str(e), filter=filter_name)
+                )
             sys.exit(1)
 
-    def decrypt_files(self, filter_name: str):
+    def decrypt_files(self, filter_name: str, emit: bool = True):
         filter_name = self._require_filter(filter_name)
         try:
             logger.info("Decrypting files for filter: %s", filter_name)
-            files_to_decrypt = self.git_attributes_parser.get_files_for_filter(
+            files = self.git_attributes_parser.get_files_for_filter(
                 filter_name=filter_name
             )
-            if not files_to_decrypt:
+            if not files:
                 logging.info(f"No files to decrypt for filter: {filter_name}")
-                return
+                if emit:
+                    msg = f"No files to decrypt for filter: {filter_name}"
+                    self.output.info(msg)
+                    self.output.result(
+                        self._envelope_ok(
+                            "decrypt-files",
+                            filter=filter_name,
+                            counts={"decrypted": 0, "skipped": 0, "total": 0},
+                            files=[],
+                            message=msg,
+                        )
+                    )
+                return {"decrypted": 0, "skipped": 0, "total": 0}
 
-            self.__get_encryption_handler(filter_name=filter_name).decrypt_files(
-                files=files_to_decrypt
-            )
+            handler = self.__get_encryption_handler(filter_name=filter_name)
+            total = len(files)
+            results = []
+            counts = {"decrypted": 0, "skipped": 0, "total": total}
+            for i, file in enumerate(files, 1):
+                self.output.progress(f"[{i}/{total}] {file}")
+                is_encrypted = self.__is_encrypted(file_path=file)
+                handler.decrypt_file(file)
+                action = "decrypted" if is_encrypted else "skipped"
+                counts[action] += 1
+                results.append({"path": file, "action": action})
+
             logging.info(f"Successfully decrypted files for filter: {filter_name}")
-            msg = f"Successfully decrypted files for filter: {filter_name}"
-            self.output.info(msg)
-            self.output.result(
-                self._envelope_ok("decrypt-files", filter=filter_name, message=msg)
-            )
+            if emit:
+                msg = f"Successfully decrypted files for filter: {filter_name}"
+                self.output.info(msg)
+                self.output.result(
+                    self._envelope_ok(
+                        "decrypt-files",
+                        filter=filter_name,
+                        counts=counts,
+                        files=results,
+                        message=msg,
+                    )
+                )
+            return counts
         except Exception as e:
             logger.error(f"Decrypt files command failed: {e}", exc_info=True)
             self.output.error(f"Decrypt files command failed: {e}")
-            self.output.result(
-                self._envelope_err("decrypt-files", str(e), filter=filter_name)
-            )
+            if emit:
+                self.output.result(
+                    self._envelope_err("decrypt-files", str(e), filter=filter_name)
+                )
             sys.exit(1)
 
     def encrypt_stdin(self, file_name):
@@ -294,10 +354,10 @@ class EncryptionManager:
             logger.info("Cleaning staged data for filter: %s", filter_name)
 
             try:
-                self.encrypt_files(filter_name=filter_name)
-            except Exception as e:
+                self.encrypt_files(filter_name=filter_name, emit=False)
+            except SystemExit:
                 logger.warning(
-                    "Failed to encrypt files for filter '%s': %s", filter_name, e
+                    "Failed to encrypt files for filter '%s' during clean", filter_name
                 )
 
             self.key_manager.remove_key_iv_from_cache(filter_name=filter_name)

--- a/src/git_secret_protector/utils/configure_logging.py
+++ b/src/git_secret_protector/utils/configure_logging.py
@@ -1,11 +1,12 @@
 import logging
 import logging.handlers
 import os
+import sys
 
 from git_secret_protector.core.settings import get_settings
 
 
-def configure_logging():
+def configure_logging(verbose=False):
     settings = get_settings()
     log_file = settings.log_file
     log_level = settings.log_level
@@ -14,11 +15,20 @@ def configure_logging():
 
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
 
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
     handler = logging.handlers.RotatingFileHandler(
         log_file, maxBytes=log_max_size, backupCount=log_backup_count
     )
-
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     handler.setFormatter(formatter)
 
-    logging.basicConfig(level=log_level, handlers=[handler])
+    handlers = [handler]
+    if verbose:
+        console = logging.StreamHandler(sys.stderr)
+        console.setFormatter(formatter)
+        console.setLevel(logging.DEBUG)
+        handlers.append(console)
+
+    logging.basicConfig(level=log_level, handlers=handlers)

--- a/tests/unit/test_configure_logging.py
+++ b/tests/unit/test_configure_logging.py
@@ -1,0 +1,38 @@
+import logging
+import logging.handlers
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+from git_secret_protector.utils.configure_logging import configure_logging
+
+
+class TestConfigureLogging(unittest.TestCase):
+    @patch("git_secret_protector.utils.configure_logging.get_settings")
+    def _run(self, verbose, mock_get_settings, tmp_log="/tmp/gsp-test.log"):
+        s = MagicMock()
+        s.log_file = tmp_log
+        s.log_level = "WARN"
+        s.log_max_size = 1048576
+        s.log_backup_count = 1
+        mock_get_settings.return_value = s
+        root = logging.getLogger()
+        root.handlers = []
+        configure_logging(verbose=verbose)
+        return root.handlers
+
+    def test_verbose_adds_stderr_stream_handler(self):
+        handlers = self._run(True)
+        stream = [
+            h
+            for h in handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.handlers.RotatingFileHandler)
+        ]
+        self.assertTrue(stream)
+        self.assertIs(stream[0].stream, sys.stderr)
+
+    def test_non_verbose_has_no_extra_stream_handler(self):
+        handlers = self._run(False)
+        stream = [h for h in handlers if type(h) is logging.StreamHandler]
+        self.assertEqual(stream, [])

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -670,6 +670,47 @@ class TestEncryptionManagerService(unittest.TestCase):
         self.assertTrue(any(c["status"] == "fail" for c in payload["checks"]))
 
     @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_json_per_filter_checks_distinguishable_with_two_filters(
+        self, mock_run
+    ):
+        # Two filters must each appear as `filter` key on every per-filter check so
+        # a machine consumer can distinguish which filter each check belongs to.
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_filter_names.return_value = ["alpha", "beta"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        # subprocess.run called twice per filter (clean + smudge) = 4 calls total
+        mock_run.side_effect = [
+            MagicMock(stdout="x\n"),
+            MagicMock(stdout="y\n"),
+            MagicMock(stdout="x\n"),
+            MagicMock(stdout="y\n"),
+        ]
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch("os.path.exists", return_value=True), patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=True
+        ):
+            with contextlib.redirect_stdout(out):
+                rc = self.manager.doctor()
+        self.assertEqual(rc, 0)
+        payload = json.loads(out.getvalue())
+        per_filter_checks = [
+            c
+            for c in payload["checks"]
+            if c.get("check") in ("git_config", "key_cache", "plaintext_scan")
+        ]
+        # Every per-filter check must carry a `filter` key
+        for c in per_filter_checks:
+            self.assertIn("filter", c, f"missing 'filter' key on check: {c}")
+        # Both filter names must appear
+        filter_values = {c["filter"] for c in per_filter_checks}
+        self.assertIn("alpha", filter_values)
+        self.assertIn("beta", filter_values)
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
     def test_doctor_human_text_unchanged(self, mock_run):
         self.git_attributes_parser.get_filter_names.return_value = ["secret"]
         self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -298,6 +298,47 @@ class TestEncryptionManagerService(unittest.TestCase):
         mock_input.assert_not_called()
         rotator.rotate_key.assert_called_once_with("secret")
 
+    def test_status_json_schema(self):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "enc.txt",
+            "plain.txt",
+        ]
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", side_effect=[True, False]
+        ):
+            with contextlib.redirect_stdout(out):
+                self.manager.status()
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["backend"], "AWS_SSM")
+        self.assertEqual(payload["filters"][0]["name"], "secret")
+        self.assertEqual(
+            payload["filters"][0]["files"],
+            [
+                {"path": "enc.txt", "encrypted": True},
+                {"path": "plain.txt", "encrypted": False},
+            ],
+        )
+
+    def test_status_human_text_unchanged(self):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "enc.txt",
+            "plain.txt",
+        ]
+        out = io.StringIO()
+        with patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", side_effect=[True, False]
+        ):
+            with contextlib.redirect_stdout(out):
+                self.manager.status()
+        self.assertIn("  enc.txt: Encrypted", out.getvalue())
+        self.assertIn("  plain.txt: ⚠ PLAINTEXT", out.getvalue())
+
     def test_status_marks_plaintext_files(self):
         self.git_attributes_parser.get_filter_names.return_value = ["secret"]
         self.git_attributes_parser.get_files_for_filter.return_value = [

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -548,6 +548,64 @@ class TestEncryptionManagerService(unittest.TestCase):
         self.assertEqual(payload["command"], "setup-filters")
         self.assertIn("no attrs", payload["error"])
 
+    def test_encrypt_files_progress_and_counts_json(self):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "a.secret",
+            "b.secret",
+        ]
+        out, err = io.StringIO(), io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch.object(
+            self.manager, "_EncryptionManager__get_encryption_handler"
+        ) as h, patch.object(
+            self.manager,
+            "_EncryptionManager__is_encrypted",
+            side_effect=[False, True],
+        ):
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                self.manager.encrypt_files("secret")
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["counts"], {"encrypted": 1, "skipped": 1, "total": 2})
+        self.assertEqual(err.getvalue(), "")  # progress suppressed under json
+
+    def test_encrypt_files_progress_to_stderr_in_normal(self):
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "a.secret",
+            "b.secret",
+        ]
+        err = io.StringIO()
+        with patch.object(
+            self.manager, "_EncryptionManager__get_encryption_handler"
+        ), patch.object(
+            self.manager,
+            "_EncryptionManager__is_encrypted",
+            return_value=False,
+        ):
+            with contextlib.redirect_stderr(err):
+                self.manager.encrypt_files("secret")
+        self.assertIn("[1/2] a.secret", err.getvalue())
+        self.assertIn("[2/2] b.secret", err.getvalue())
+
+    def test_clean_filter_no_nested_envelope(self):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.secret"]
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch.object(
+            self.manager, "_EncryptionManager__get_encryption_handler"
+        ), patch.object(
+            self.manager,
+            "_EncryptionManager__is_encrypted",
+            return_value=False,
+        ):
+            with contextlib.redirect_stdout(out):
+                self.manager.clean_filter("secret")
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["command"], "clean-filter")  # not encrypt-files
+
 
 class TestMain(unittest.TestCase):
     @patch("git_secret_protector.main.EncryptionManager.show_project_version")

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -492,6 +492,45 @@ class TestEncryptionManagerService(unittest.TestCase):
                 cache_path = os.path.join(temp_dir, "secret_key_iv.json")
                 self.assertEqual(oct(os.stat(cache_path).st_mode & 0o777), "0o600")
 
+    def test_setup_aes_key_json_envelope(self):
+        from git_secret_protector.core.output import Output
+
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with contextlib.redirect_stdout(out):
+            self.manager.setup_aes_key("secret")
+        payload = json.loads(out.getvalue())
+        self.assertEqual(
+            payload,
+            {
+                "ok": True,
+                "command": "setup-aes-key",
+                "filter": "secret",
+                "message": "Successfully set up AES key for filter: secret",
+            },
+        )
+
+    def test_setup_aes_key_json_error_envelope_and_exit(self):
+        from git_secret_protector.core.output import Output
+
+        self.key_manager.setup_aes_key_and_iv.side_effect = RuntimeError("boom")
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as ctx:
+                self.manager.setup_aes_key("secret")
+        self.assertEqual(ctx.exception.code, 1)
+        payload = json.loads(out.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["command"], "setup-aes-key")
+        self.assertIn("boom", payload["error"])
+
+    def test_setup_aes_key_human_text_unchanged(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.manager.setup_aes_key("secret")
+        self.assertIn("Successfully set up AES key for filter: secret", out.getvalue())
+
 
 class TestMain(unittest.TestCase):
     @patch("git_secret_protector.main.EncryptionManager.show_project_version")
@@ -501,7 +540,7 @@ class TestMain(unittest.TestCase):
     ):
         show_project_version(None)
 
-        mock_show_project_version.assert_called_once_with()
+        mock_show_project_version.assert_called_once_with(None, None)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -531,6 +531,23 @@ class TestEncryptionManagerService(unittest.TestCase):
             self.manager.setup_aes_key("secret")
         self.assertIn("Successfully set up AES key for filter: secret", out.getvalue())
 
+    def test_setup_filters_json_error_envelope_and_exit_when_parser_raises(self):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_filter_names.side_effect = RuntimeError(
+            "no attrs"
+        )
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as ctx:
+                self.manager.setup_filters()
+        self.assertEqual(ctx.exception.code, 1)
+        payload = json.loads(out.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["command"], "setup-filters")
+        self.assertIn("no attrs", payload["error"])
+
 
 class TestMain(unittest.TestCase):
     @patch("git_secret_protector.main.EncryptionManager.show_project_version")

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -647,6 +647,47 @@ class TestEncryptionManagerService(unittest.TestCase):
         payload = json.loads(out.getvalue())
         self.assertEqual(payload["command"], "clean-filter")  # not encrypt-files
 
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_json_schema_and_exit(self, mock_run):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        mock_run.side_effect = [MagicMock(stdout="x\n"), MagicMock(stdout="y\n")]
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch("os.path.exists", return_value=True), patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=False
+        ):
+            with contextlib.redirect_stdout(out):
+                rc = self.manager.doctor()
+        self.assertEqual(rc, 1)
+        payload = json.loads(out.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["exit_code"], 1)
+        self.assertTrue(any(c["status"] == "fail" for c in payload["checks"]))
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_human_text_unchanged(self, mock_run):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        mock_run.side_effect = [MagicMock(stdout="x\n"), MagicMock(stdout="y\n")]
+        out = io.StringIO()
+        with patch("os.path.exists", return_value=True), patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=True
+        ):
+            with contextlib.redirect_stdout(out):
+                self.manager.doctor()
+        text = out.getvalue()
+        self.assertIn("[ OK ] filters declared: secret", text)
+        self.assertIn(
+            "[ OK ] all tracked secret files are encrypted for 'secret'", text
+        )
+
 
 class TestMain(unittest.TestCase):
     @patch("git_secret_protector.main.EncryptionManager.show_project_version")

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -132,3 +132,31 @@ def test_json_flag_after_subcommand_parses(tmp_path):
     import json
 
     json.loads(result.stdout)  # stdout is a valid JSON document
+
+
+def test_repo_root_after_subcommand_is_accepted(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+    (repo / "example.secret").write_text("plain\n")
+
+    result = _run_main(["status", "--repo-root", str(repo)], tmp_path)
+
+    assert result.returncode == 0
+    assert "Filter: secret" in result.stdout
+
+
+def test_quiet_after_subcommand_is_accepted(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+
+    # --repo-root before subcommand, --quiet after - both must parse
+    result = _run_main(["--repo-root", str(repo), "status", "--quiet"], tmp_path)
+
+    # quiet suppresses info output but command must succeed
+    assert result.returncode == 0
+    # no "Filter:" line in quiet mode - success is returncode 0 with no error
+    assert "git repository" not in result.stderr

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -108,3 +108,27 @@ def test_help_includes_typical_workflow_epilog(tmp_path):
 
     assert result.returncode == 0
     assert "Typical workflow" in result.stdout
+
+
+def test_quiet_and_verbose_conflict_exits_2(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+    result = _run_main(
+        ["--repo-root", str(repo), "--quiet", "--verbose", "status"], tmp_path
+    )
+    assert result.returncode == 2
+    assert "quiet" in result.stderr.lower()
+
+
+def test_json_flag_after_subcommand_parses(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+    result = _run_main(["--repo-root", str(repo), "status", "--json"], tmp_path)
+    assert result.returncode == 0
+    import json
+
+    json.loads(result.stdout)  # stdout is a valid JSON document

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -160,3 +160,86 @@ def test_quiet_after_subcommand_is_accepted(tmp_path):
     assert result.returncode == 0
     # no "Filter:" line in quiet mode - success is returncode 0 with no error
     assert "git repository" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# stdout-purity guard: encrypt/decrypt must never mix log/status bytes into
+# the payload stream regardless of output flags.
+# ---------------------------------------------------------------------------
+
+import base64
+import json
+import os as _os
+
+
+def _seed_key_cache(repo, filter_name: str) -> None:
+    """Write a local AES key cache so the CLI never touches a storage backend."""
+    cache_dir = repo / ".git_secret_protector" / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    key_data = {
+        "aes_key": base64.b64encode(_os.urandom(32)).decode(),
+        "iv": base64.b64encode(_os.urandom(16)).decode(),
+        "version": 2,
+    }
+    cache_file = cache_dir / f"{filter_name}_key_iv.json"
+    cache_file.write_text(json.dumps(key_data))
+    cache_file.chmod(0o600)
+
+
+def _run_filter(args, cwd, stdin_bytes):
+    """Run the CLI in binary mode; used for encrypt/decrypt filter commands."""
+    env = _os.environ.copy()
+    env.pop("SECRET_PROTECTOR_BASE_DIR", None)
+    pythonpath = str(ROOT / "src")
+    env["PYTHONPATH"] = (
+        f"{pythonpath}{_os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else pythonpath
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "git_secret_protector.main", *args],
+        cwd=str(cwd),
+        env=env,
+        input=stdin_bytes,
+        capture_output=True,
+        # No text=True - we need raw bytes on stdout
+    )
+
+
+def test_encrypt_decrypt_stdout_is_pure_bytes_under_all_flags(tmp_path):
+    """encrypt/decrypt stdout must equal exact payload bytes for every flag combo."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=secret\n")
+
+    # Seed the local key cache so the CLI never contacts AWS/GCP.
+    # Must happen before the first CLI run (init_module_folder creates the dirs,
+    # but _seed_key_cache creates them too via parents=True so order doesn't matter).
+    _seed_key_cache(repo, "secret")
+
+    plaintext = b"hello-secret-payload"
+
+    flag_sets = [
+        [],
+        ["--json"],
+        ["--quiet"],
+        ["--verbose"],
+    ]
+
+    for flags in flag_sets:
+        enc = _run_filter(
+            [*flags, "encrypt", "x.secret"], cwd=repo, stdin_bytes=plaintext
+        )
+        assert enc.returncode == 0, f"encrypt failed (flags={flags}): {enc.stderr!r}"
+        ciphertext = enc.stdout
+        assert ciphertext != plaintext, f"encrypt produced plaintext (flags={flags})"
+
+        dec = _run_filter(
+            [*flags, "decrypt", "x.secret"], cwd=repo, stdin_bytes=ciphertext
+        )
+        assert dec.returncode == 0, f"decrypt failed (flags={flags}): {dec.stderr!r}"
+        assert dec.stdout == plaintext, (
+            f"stdout purity violated with flags={flags}: "
+            f"got {dec.stdout[:60]!r}, expected {plaintext!r}"
+        )

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,0 +1,53 @@
+# tests/unit/test_output.py
+import contextlib
+import io
+import json
+import unittest
+
+from git_secret_protector.core.output import Output
+
+
+class TestOutput(unittest.TestCase):
+    def _capture(self, fn):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            fn()
+        return out.getvalue(), err.getvalue()
+
+    def test_normal_info_to_stdout(self):
+        out, err = self._capture(lambda: Output().info("hi"))
+        self.assertEqual(out, "hi\n")
+        self.assertEqual(err, "")
+
+    def test_error_to_stderr_always(self):
+        out, err = self._capture(lambda: Output(quiet=True).error("boom"))
+        self.assertEqual(out, "")
+        self.assertEqual(err, "boom\n")
+
+    def test_quiet_suppresses_info_and_progress(self):
+        out, err = self._capture(
+            lambda: (Output(quiet=True).info("x"), Output(quiet=True).progress("p"))
+        )
+        self.assertEqual(out, "")
+        self.assertEqual(err, "")
+
+    def test_progress_to_stderr_in_normal(self):
+        out, err = self._capture(lambda: Output().progress("[1/2] a"))
+        self.assertEqual(out, "")
+        self.assertEqual(err, "[1/2] a\n")
+
+    def test_json_result_to_stdout(self):
+        out, err = self._capture(lambda: Output(json=True).result({"ok": True}))
+        self.assertEqual(json.loads(out), {"ok": True})
+        self.assertEqual(err, "")
+
+    def test_json_suppresses_info_and_progress(self):
+        out, err = self._capture(
+            lambda: (Output(json=True).info("x"), Output(json=True).progress("p"))
+        )
+        self.assertEqual(out, "")
+        self.assertEqual(err, "")
+
+    def test_result_noop_in_human_mode(self):
+        out, err = self._capture(lambda: Output().result({"ok": True}))
+        self.assertEqual(out, "")

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -51,3 +51,7 @@ class TestOutput(unittest.TestCase):
     def test_result_noop_in_human_mode(self):
         out, err = self._capture(lambda: Output().result({"ok": True}))
         self.assertEqual(out, "")
+
+    def test_quiet_property(self):
+        self.assertTrue(Output(quiet=True).quiet)
+        self.assertFalse(Output().quiet)


### PR DESCRIPTION
## Summary

### Why
The CLI had no way to control output verbosity or produce machine-readable results. Scripts and CI could not consume `status`/`doctor` reliably, bulk operations gave no progress feedback, and there was no quiet mode.

### What
Adds three global flags (accepted before or after the subcommand):
- `--quiet` - suppress success/info output (errors and exit codes unchanged).
- `--verbose` - emit internal logs to stderr (logging was file-only).
- `--json` - machine-readable JSON for `status`, `doctor`, `version`, and the action commands (uniform `{ok, command, ...}` envelope; bulk `encrypt-files`/`decrypt-files` add a `counts` object).

Plus per-file progress on bulk encrypt/decrypt (stderr; suppressed under `--quiet`/`--json`).

### Solution
A single `Output` router (`core/output.py`) centralizes stdout/stderr/json routing, configured once in `main()` and injector-bound. `status`/`doctor` build a full structured dict then fork at the end on `--json` (atomic; errors emit `{ok:false,...}` + nonzero exit; `doctor` preserves its exit code in both modes).

**Safety-critical invariant:** the `encrypt`/`decrypt` clean/smudge filter path is exempt from the output layer - its stdout is the raw file payload that git stores, so no flag may add a byte to it. A guard-rail test runs a real encrypt->decrypt round-trip under every flag combination and asserts byte-identical output.

Design and plan are committed under `docs/specs/cli-output-controls/` and `docs/plans/cli-output-controls/`.

## Types of Changes
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- `poetry run pytest tests/unit/` - 94 passed.
- Guard-rail `test_encrypt_decrypt_stdout_is_pure_bytes_under_all_flags` proves filter stdout purity under `[]`/`--json`/`--quiet`/`--verbose`.
- Human-mode output for every command is snapshot-locked to its prior text; `doctor` exit code verified in both human and JSON modes.
