### PR TITLE
feat(cli): add interactive init command for backend + module_name

### DIFF
--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -118,6 +118,17 @@ def show_project_version(args, output=None):
     EncryptionManager.show_project_version(args, output)
 
 
+def init_command(args):
+    sys.exit(
+        EncryptionManager.init_config(
+            backend=getattr(args, "backend", None),
+            module_name=getattr(args, "module_name", None),
+            assume_yes=getattr(args, "yes", False),
+            force=getattr(args, "force", False),
+        )
+    )
+
+
 def main():
     # Shared parent inherited by both the top-level parser and every subparser.
     # SUPPRESS means an absent flag sets NO attribute, so a subparser parse
@@ -263,6 +274,37 @@ def main():
     )
     parser_version.set_defaults(func=show_project_version)
 
+    # Init command - writes config.ini interactively
+    parser_init = subparsers.add_parser(
+        "init",
+        help="Initialize git-secret-protector config (writes config.ini)",
+        parents=[common],
+    )
+    parser_init.add_argument(
+        "--backend",
+        choices=["AWS_SSM", "GCP_SECRET"],
+        default=None,
+        help="Storage backend (default: prompt or AWS_SSM with --yes)",
+    )
+    parser_init.add_argument(
+        "--module-name",
+        dest="module_name",
+        default=None,
+        help="Module name written into config.ini (default: prompt or git-secret-protector with --yes)",
+    )
+    parser_init.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Non-interactive: accept all defaults, skip prompts",
+    )
+    parser_init.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing config.ini without prompting",
+    )
+    parser_init.set_defaults(func=init_command)
+
     args = parser.parse_args()
     if not hasattr(args, "func"):
         parser.print_help()
@@ -279,7 +321,7 @@ def main():
     )
 
     try:
-        if args.func is not show_project_version:
+        if args.func not in (show_project_version, init_command):
             if getattr(args, "repo_root", None):
                 repo_root = Path(args.repo_root).resolve()
                 if not repo_root.is_dir():
@@ -296,8 +338,10 @@ def main():
             global manager
             manager = GitSecretProtectorModule.get_injector().get(EncryptionManager)
             args.func(args)
-        else:
+        elif args.func is show_project_version:
             show_project_version(args, output)
+        else:
+            args.func(args)
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -1,3 +1,4 @@
+import configparser
 import logging
 import os
 import subprocess
@@ -8,7 +9,7 @@ import injector
 
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
 from git_secret_protector.core.output import Output
-from git_secret_protector.core.settings import get_settings
+from git_secret_protector.core.settings import StorageType, get_settings
 from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
 from git_secret_protector.crypto.aes_key_manager import AesKeyManager
 from git_secret_protector.services.key_rotator import KeyRotator
@@ -606,6 +607,100 @@ class EncryptionManager:
             logger.error(f"Failed to get project version: {e}", exc_info=True)
             output.error(f"Failed to get project version: {str(e)}")
             output.result({"ok": False, "command": "version", "error": str(e)})
+
+    @staticmethod
+    def init_config(
+        backend=None, module_name=None, assume_yes=False, force=False
+    ) -> int:
+        """Write .git_secret_protector/config.ini interactively or non-interactively.
+
+        Returns 0 on success or non-destructive skip, 1 on invalid input.
+        """
+        settings = get_settings()
+        pre_existing = os.path.exists(settings.config_file)
+
+        if pre_existing and not force:
+            if assume_yes:
+                print(
+                    "config.ini already exists; pass --force to overwrite.",
+                    file=sys.stderr,
+                )
+                return 0
+            # Interactive: mirror the EOF-safe pattern from rotate_keys.
+            try:
+                answer = input(
+                    f"config.ini already exists at {settings.config_file}. Overwrite? [y/N] "
+                )
+            except EOFError:
+                answer = ""
+            if answer.strip().lower() not in {"y", "yes"}:
+                print("Keeping existing config.", file=sys.stderr)
+                return 0
+
+        # Resolve backend.
+        valid_backends = {m.value for m in StorageType}
+        if backend is not None:
+            if backend not in valid_backends:
+                print(
+                    f"Error: invalid backend '{backend}'. Choose from: {', '.join(sorted(valid_backends))}",
+                    file=sys.stderr,
+                )
+                return 1
+        elif assume_yes:
+            backend = "AWS_SSM"
+        else:
+            try:
+                raw = input("Storage backend [AWS_SSM/GCP_SECRET] (default AWS_SSM): ")
+            except EOFError:
+                raw = ""
+            backend = raw.strip() or "AWS_SSM"
+            if backend not in valid_backends:
+                # One reprompt.
+                try:
+                    raw2 = input(
+                        f"Invalid backend '{backend}'. Choose AWS_SSM or GCP_SECRET: "
+                    )
+                except EOFError:
+                    raw2 = ""
+                backend = raw2.strip() or ""
+                if backend not in valid_backends:
+                    print(
+                        f"Error: invalid backend '{backend}'. Choose from: {', '.join(sorted(valid_backends))}",
+                        file=sys.stderr,
+                    )
+                    return 1
+
+        # Resolve module_name.
+        if module_name is not None:
+            pass  # use as-is
+        elif assume_yes:
+            module_name = "git-secret-protector"
+        else:
+            try:
+                raw = input("Module name (default git-secret-protector): ")
+            except EOFError:
+                raw = ""
+            module_name = raw.strip() or "git-secret-protector"
+
+        # Create directories.
+        module_dir = Path(settings.module_dir)
+        (module_dir / "cache").mkdir(parents=True, exist_ok=True)
+        (module_dir / "logs").mkdir(parents=True, exist_ok=True)
+
+        # Write config.
+        cfg = configparser.ConfigParser()
+        cfg["DEFAULT"] = {
+            "module_name": module_name,
+            "storage_type": backend,
+            "log_level": "WARN",
+            "log_max_size": "1048576",
+        }
+        with open(settings.config_file, "w") as fh:
+            cfg.write(fh)
+
+        print(f"Initialized git-secret-protector config at {settings.config_file}")
+        print(f"  backend: {backend}\n  module_name: {module_name}")
+        return 0
 
     @staticmethod
     def _get_poetry_root_path():

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -1,4 +1,5 @@
 import base64
+import configparser
 import contextlib
 import io
 import json
@@ -739,6 +740,124 @@ class TestMain(unittest.TestCase):
         show_project_version(None)
 
         mock_show_project_version.assert_called_once_with(None, None)
+
+
+class TestInitConfig(unittest.TestCase):
+    """Unit tests for EncryptionManager.init_config staticmethod."""
+
+    def _make_mock_settings(self, tmp_dir):
+        """Return a mock Settings pointing at tmp_dir."""
+        mock_settings = MagicMock()
+        module_dir = os.path.join(tmp_dir, ".git_secret_protector")
+        mock_settings.base_dir = tmp_dir
+        mock_settings.module_dir = module_dir
+        mock_settings.config_file = os.path.join(module_dir, "config.ini")
+        return mock_settings
+
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def test_init_config_writes_config_when_none_exists(self, mock_get_settings):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mock_get_settings.return_value = self._make_mock_settings(tmp_dir)
+            stdout = io.StringIO()
+
+            with contextlib.redirect_stdout(stdout):
+                rc = EncryptionManager.init_config(
+                    backend="GCP_SECRET", module_name="x", assume_yes=True
+                )
+
+            self.assertEqual(rc, 0)
+            config_file = os.path.join(tmp_dir, ".git_secret_protector", "config.ini")
+            self.assertTrue(os.path.exists(config_file))
+            cfg = configparser.ConfigParser()
+            cfg.read(config_file)
+            self.assertEqual(cfg["DEFAULT"]["storage_type"], "GCP_SECRET")
+            self.assertEqual(cfg["DEFAULT"]["module_name"], "x")
+            self.assertIn("Initialized", stdout.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def test_init_config_assume_yes_no_force_skips_existing(self, mock_get_settings):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mock_settings = self._make_mock_settings(tmp_dir)
+            mock_get_settings.return_value = mock_settings
+            # Pre-create config
+            module_dir = mock_settings.module_dir
+            os.makedirs(module_dir, exist_ok=True)
+            config_file = mock_settings.config_file
+            original_content = "[DEFAULT]\nmodule_name = original\n"
+            with open(config_file, "w") as f:
+                f.write(original_content)
+
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                rc = EncryptionManager.init_config(assume_yes=True, force=False)
+
+            self.assertEqual(rc, 0)
+            # File must not have been modified
+            with open(config_file) as f:
+                self.assertEqual(f.read(), original_content)
+            self.assertIn("--force", stderr.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def test_init_config_force_overwrites_existing(self, mock_get_settings):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mock_settings = self._make_mock_settings(tmp_dir)
+            mock_get_settings.return_value = mock_settings
+            module_dir = mock_settings.module_dir
+            os.makedirs(module_dir, exist_ok=True)
+            config_file = mock_settings.config_file
+            with open(config_file, "w") as f:
+                f.write("[DEFAULT]\nmodule_name = old\n")
+
+            rc = EncryptionManager.init_config(
+                backend="GCP_SECRET",
+                module_name="new-module",
+                assume_yes=True,
+                force=True,
+            )
+
+            self.assertEqual(rc, 0)
+            cfg = configparser.ConfigParser()
+            cfg.read(config_file)
+            self.assertEqual(cfg["DEFAULT"]["module_name"], "new-module")
+            self.assertEqual(cfg["DEFAULT"]["storage_type"], "GCP_SECRET")
+
+    @patch("builtins.input", side_effect=EOFError)
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def test_init_config_interactive_eof_declines_overwrite(
+        self, mock_get_settings, mock_input
+    ):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mock_settings = self._make_mock_settings(tmp_dir)
+            mock_get_settings.return_value = mock_settings
+            module_dir = mock_settings.module_dir
+            os.makedirs(module_dir, exist_ok=True)
+            config_file = mock_settings.config_file
+            original_content = "[DEFAULT]\nmodule_name = original\n"
+            with open(config_file, "w") as f:
+                f.write(original_content)
+
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                rc = EncryptionManager.init_config(assume_yes=False, force=False)
+
+            self.assertEqual(rc, 0)
+            with open(config_file) as f:
+                self.assertEqual(f.read(), original_content)
+            self.assertIn("Keeping existing config", stderr.getvalue())
+
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def test_init_config_invalid_explicit_backend_returns_1(self, mock_get_settings):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mock_get_settings.return_value = self._make_mock_settings(tmp_dir)
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr):
+                rc = EncryptionManager.init_config(
+                    backend="INVALID_BACKEND", assume_yes=True
+                )
+
+            self.assertEqual(rc, 1)
+            self.assertIn("INVALID_BACKEND", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -206,6 +206,24 @@ def _run_filter(args, cwd, stdin_bytes):
     )
 
 
+def test_init_creates_config_in_fresh_git_repo(tmp_path):
+    """init --yes in a bare git repo (no .git_secret_protector) must create config.ini."""
+    import configparser
+
+    _init_git_repo(tmp_path)
+    result = _run_main(
+        ["init", "--yes", "--backend", "GCP_SECRET", "--module-name", "demo"],
+        tmp_path,
+    )
+    assert result.returncode == 0, f"init failed: {result.stderr}"
+    config_file = tmp_path / ".git_secret_protector" / "config.ini"
+    assert config_file.exists(), "config.ini was not created"
+    cfg = configparser.ConfigParser()
+    cfg.read(str(config_file))
+    assert cfg["DEFAULT"]["storage_type"] == "GCP_SECRET"
+    assert cfg["DEFAULT"]["module_name"] == "demo"
+
+
 def test_encrypt_decrypt_stdout_is_pure_bytes_under_all_flags(tmp_path):
     """encrypt/decrypt stdout must equal exact payload bytes for every flag combo."""
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary

### Why
Setting up a repo required hand-editing `.git_secret_protector/config.ini` to choose the storage backend and module name. There was no guided setup.

### What
Adds an interactive `init` command that prompts for the storage backend (`AWS_SSM` | `GCP_SECRET`) and module name, then writes `config.ini`. Flags:
- `--backend {AWS_SSM,GCP_SECRET}` / `--module-name NAME` to supply values directly.
- `-y`/`--yes` for non-interactive/scripted use (defaults: `AWS_SSM`, `git-secret-protector`).
- `--force` to overwrite an existing config.

### Solution
`init` is non-destructive: an existing `config.ini` is never overwritten without `--force` or an explicit interactive "yes" (EOF is treated as a safe decline, matching the `rotate-key` confirm pattern). It is special-cased in `main()` to run before the eager `init_module_folder()` auto-init, so the "already exists?" check sees the true pre-existing state. The work lives in `EncryptionManager.init_config(...)`; the backend value is validated against `StorageType`.

## Types of Changes
- [x] 🚀 New feature (non-breaking change which adds functionality)

## Test Plan
- `poetry run pytest tests/unit/` - 100 passed.
- Covers: fresh-repo create, non-destructive skip under `--yes` (file byte-unchanged), `--force` overwrite, EOF-decline leaves file unchanged, invalid backend exits 1, and a CLI-level `init --yes --backend GCP_SECRET --module-name demo` round-trip.
