### PR TITLE
feat: encryption scheme versioning (v1/v2 coexistence, upgrade-scheme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,62 @@ git-secret-protector --json status   # flag position before or after subcommand 
 
 Logs are stored in the `.git_secret_protector/logs/` directory by default, and you can configure the log level and file rotation in the `config.ini` file.
 
+### 6. Encryption Scheme Versioning
+
+`git-secret-protector` supports two encryption schemes:
+
+- **v2** (default) - authenticated AES-256-CTR + HMAC-SHA256. This is the secure default for all new filters.
+- **v1** (legacy) - unauthenticated AES-CBC, kept only for backward compatibility with clients older than 1.4.0 that cannot read v2-encrypted files.
+
+Decryption automatically handles both formats. Any file encrypted with v1 is still readable after you set up a v2 key, so the migration is safe to perform at any time.
+
+#### Setting the scheme when creating a key
+
+By default, `setup-aes-key` creates a v2 key:
+
+```sh
+git-secret-protector setup-aes-key <filter_name>
+```
+
+To create a v1 key for a filter that still has pre-1.4.0 clients:
+
+```sh
+git-secret-protector setup-aes-key <filter_name> --scheme v1
+```
+
+> **SECURITY NOTE:** v1 is unauthenticated. An attacker with write access to the ciphertext can tamper with it without detection. Use `--scheme v1` only when you have no other option (old clients that cannot be upgraded). Migrate away from v1 as soon as all clients are on 1.4.0 or later (see `upgrade-scheme` below).
+
+#### Migrating a filter from v1 to v2
+
+Once all clients on a repository are on 1.4.0 or later, run:
+
+```sh
+git-secret-protector upgrade-scheme <filter_name>
+```
+
+This command:
+- Re-encrypts all files matched by the filter using v2.
+- Updates the stored key blob so future encryptions also use v2.
+- Is confirm-gated (use `-y` / `--yes` to skip the prompt in automation).
+- Is idempotent - running it on an already-v2 filter is a no-op.
+- Is one-way - there is no downgrade command.
+
+#### Checking the active scheme
+
+`status` shows the active scheme for each filter:
+
+```sh
+git-secret-protector status
+```
+
+`doctor` also shows the scheme and flags any v1 filter as a `[WARN]`:
+
+```sh
+git-secret-protector doctor
+```
+
+A filter using v1 is reported as `[WARN]` to prompt migration; a v2 filter reports `[ OK ]`.
+
 ## Development
 
 ### Running Tests

--- a/docs/plans/encryption-versioning/2026-06-22-scheme-versioning-plan.md
+++ b/docs/plans/encryption-versioning/2026-06-22-scheme-versioning-plan.md
@@ -1,0 +1,245 @@
+# Encryption Scheme Versioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** Make the encryption scheme (v1 legacy CBC / v2 authenticated) a property of the stored key blob so 1.2.x and 1.4.0+ clients coexist; add `setup-aes-key --scheme`, `upgrade-scheme`, and scheme surfacing in status/doctor.
+
+**Design source:** `docs/specs/encryption-versioning/2026-06-22-scheme-versioning-design.md` (read it for full rationale).
+
+**Tech Stack:** Python 3.9, pycryptodome (AES/HMAC/HKDF - already a dep), argparse, injector.
+
+## Global Constraints
+
+- Python 3.9; no new dependencies. Formatter `black` pinned `24.8.0` (format only touched files).
+- DECRYPT stays version-byte-authoritative (`_perform_decryption` dispatch on the wire `0x02` byte) and is INDEPENDENT of the key blob scheme. Do not couple them.
+- The `encrypt`/`decrypt` stdin filter path stays stdout-pure (binary payload only) - the existing guard-rail test must still pass.
+- v1 is unauthenticated AES-CBC: the downgrade must be LOUD (warn on setup, `[WARN]` in doctor, surfaced in status). Never silent.
+- New keys default to v2; `AesEncryptionHandler` `scheme` param defaults to `"v2"` so existing call sites are unchanged.
+- Human-mode output of existing commands stays byte-identical except for the NEW additive scheme lines.
+- Test command: `poetry run pytest tests/unit/`.
+- AES key is 32 bytes, IV 16 bytes (valid for AES-256-CBC).
+
+---
+
+### Task 1: Scheme-aware `AesEncryptionHandler` (v1 encrypt branch)
+
+**Files:**
+- Modify: `src/git_secret_protector/crypto/aes_encryption_handler.py`
+- Test: `tests/unit/test_encryption_handler.py` (or the existing handler test file - inspect; the crypto tests live in `tests/unit/test_encryption_manager.py` `TestEncryptionManager` and possibly a dedicated file. Add to whichever holds `AesEncryptionHandler` unit tests; create `tests/unit/test_encryption_handler.py` if none).
+
+**Interfaces:**
+- Produces: `AesEncryptionHandler(aes_key, iv, magic_header, scheme="v2")`. `_perform_encryption` branches on `self.scheme`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# v1 encrypt must round-trip through the existing v1 decrypt path, be deterministic,
+# and NOT carry the 0x02 version byte. v2 path must be unchanged.
+import secrets
+from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
+
+MH = b"ENCRYPTED"
+
+def _h(scheme):
+    return AesEncryptionHandler(aes_key=secrets.token_bytes(32), iv=secrets.token_bytes(16),
+                                magic_header=MH, scheme=scheme)
+
+def test_v1_roundtrip_and_deterministic():
+    h = _h("v1")
+    data = b"super-secret-value"
+    ct1 = h.encrypt_data(data)
+    ct2 = h.encrypt_data(data)
+    assert ct1.startswith(MH)
+    assert ct1[len(MH):len(MH)+1] != b"\x02"   # v1 has no version byte
+    assert ct1 == ct2                            # deterministic (fixed stored IV)
+    assert h.decrypt_data(ct1) == data           # decrypt dispatches via wire bytes
+
+def test_v2_still_default_and_authenticated():
+    h = _h("v2")
+    data = b"abc"
+    ct = h.encrypt_data(data)
+    assert ct[len(MH):len(MH)+1] == b"\x02"
+    assert h.decrypt_data(ct) == data
+
+def test_scheme_defaults_to_v2():
+    h = AesEncryptionHandler(aes_key=secrets.token_bytes(32), iv=secrets.token_bytes(16), magic_header=MH)
+    assert h.encrypt_data(b"x")[len(MH):len(MH)+1] == b"\x02"
+
+def test_magic_header_short_circuit_both_schemes():
+    for s in ("v1", "v2"):
+        h = _h(s)
+        already = MH + b"whatever"
+        assert h.encrypt_data(already) == already
+```
+
+- [ ] **Step 2: Run -> fail** (`scheme` kwarg unknown / v1 produces v2)
+
+Run: `poetry run pytest tests/unit/test_encryption_handler.py -v`
+
+- [ ] **Step 3: Implement**
+
+In `__init__` add `scheme="v2"` and store `self.scheme = scheme`. Split `_perform_encryption`:
+
+```python
+def _perform_encryption(self, data: bytes) -> bytes:
+    if data.startswith(self.magic_header):
+        logger.info("Data already contains MAGIC_HEADER. Skipping encryption.")
+        return data
+    if self.scheme == "v1":
+        return self._encrypt_v1(data)
+    return self._encrypt_v2(data)
+
+def _encrypt_v1(self, data: bytes) -> bytes:
+    from Crypto.Util.Padding import pad  # already imported at top; reuse existing import
+    ciphertext = AES.new(self.aes_key, AES.MODE_CBC, self.iv).encrypt(pad(data, AES.block_size))
+    return self.magic_header + base64.b64encode(ciphertext)
+
+def _encrypt_v2(self, data: bytes) -> bytes:
+    iv = HMAC.new(self._iv_key, data, SHA256).digest()[:16]
+    ctr = Counter.new(128, initial_value=int.from_bytes(iv, "big"))
+    ciphertext = AES.new(self._enc_key, AES.MODE_CTR, counter=ctr).encrypt(data)
+    tag = HMAC.new(self._mac_key, iv + ciphertext, SHA256).digest()
+    return self.magic_header + self.V2 + base64.b64encode(iv + ciphertext + tag)
+```
+
+(Move the existing v2 body verbatim into `_encrypt_v2`. `pad` is already imported at module top - do not re-import; the inline import above is illustrative, use the top-level one.) Leave `_perform_decryption` untouched.
+
+- [ ] **Step 4: Run -> pass**; then full suite `poetry run pytest tests/unit/`.
+- [ ] **Step 5: Format + commit** `feat(crypto): scheme-aware encryption handler with v1 legacy encrypt`
+
+---
+
+### Task 2: Key blob scheme - `setup_aes_key_and_iv(scheme)`, `get_scheme`, `set_scheme`
+
+**Files:**
+- Modify: `src/git_secret_protector/crypto/aes_key_manager.py`
+- Test: `tests/unit/test_aes_key_manager.py` (inspect existing; add if absent)
+
+**Interfaces:**
+- `setup_aes_key_and_iv(self, filter_name, scheme="v2")` - writes `"version": 1` if scheme=="v1" else `2`.
+- `get_scheme(self, filter_name) -> "v1"|"v2"` - reads the blob (cache-first via the same path `retrieve_key_and_iv` uses), maps `version` 1->"v1" else "v2" (absent->"v2").
+- `set_scheme(self, filter_name, scheme)` - rewrites the stored blob's `version` (preserving aes_key/iv) in BOTH the storage backend and the local cache.
+
+- [ ] **Step 1: Write failing tests** - mock the storage manager + use a tmp cache dir (mirror existing key-manager test setup; if none, patch `get_settings` to a tmp dir and patch `_get_storage_manager`). Cover:
+  - setup with scheme="v1" writes a blob whose `version` == 1; default writes 2.
+  - get_scheme returns "v1" for version 1, "v2" for version 2, "v2" when version absent.
+  - set_scheme(filter, "v2") rewrites version to 2 while preserving aes_key/iv (assert by reloading), updates both backend store and cache.
+
+- [ ] **Step 2: Run -> fail.**
+
+- [ ] **Step 3: Implement.**
+  - In `setup_aes_key_and_iv`, accept `scheme="v2"`, set `"version": 1 if scheme == "v1" else 2` in `data`.
+  - `get_scheme`: load blob via `load_key_iv_from_cache` first, else backend `retrieve` + `json.loads`; `v = data.get("version", 2)`; return `"v1" if v == 1 else "v2"`. Wrap in the existing error->AesKeyError style only if a read fails in a way callers expect; otherwise default safely to "v2" on a malformed/missing version field (do NOT crash status/doctor on a read miss - but a missing KEY entirely should still raise as today).
+  - `set_scheme`: read current blob (backend authoritative), set `data["version"] = 2 if scheme=="v2" else 1`, `store(parameter_name, json.dumps(data))`, then `cache_key_iv_locally(filter_name, json.dumps(data))`.
+
+- [ ] **Step 4: Run -> pass; full suite.**
+- [ ] **Step 5: Format + commit** `feat(keys): store encryption scheme in key blob (setup/get/set_scheme)`
+
+---
+
+### Task 3: Wire scheme into handler + `setup-aes-key --scheme` + warning
+
+**Files:**
+- Modify: `src/git_secret_protector/services/encryption_manager.py` (`__get_encryption_handler`, `setup_aes_key`)
+- Modify: `src/git_secret_protector/main.py` (`--scheme` on setup-aes-key; pass through)
+- Test: `tests/unit/test_encryption_manager.py`, `tests/unit/test_main_cli.py`
+
+**Interfaces:**
+- `__get_encryption_handler` builds the handler with `scheme=self.key_manager.get_scheme(filter_name)`.
+- `setup_aes_key(self, filter_name, scheme="v2")` -> passes scheme to `key_manager.setup_aes_key_and_iv`; on v1 emits the security warning via `self.output.error(...)`; JSON envelope includes `"scheme"`.
+- main: setup-aes-key subparser gains `--scheme` choices `v1`,`v2` default `v2`; `setup_aes_key` handler passes `args.scheme`.
+
+- [ ] **Step 1: Failing tests**
+  - `__get_encryption_handler` constructs handler with the filter's scheme (patch get_scheme -> "v1", assert handler.scheme == "v1"). Access via the name-mangled method.
+  - `setup_aes_key(scheme="v1")` calls `key_manager.setup_aes_key_and_iv(filter_name, scheme="v1")` and writes a stderr line containing "WARNING" and "v1"; JSON envelope has `scheme=="v1"`.
+  - CLI: `setup-aes-key <f> --scheme v1` parses and reaches the manager with scheme v1 (can assert via a mock or via the warning text in stderr in a subprocess test with a seeded backend; if backend calls are unavoidable, keep this as a unit test on the handler function instead).
+
+- [ ] **Step 2-4:** implement, run, full suite.
+- [ ] **Step 5: commit** `feat(cli): setup-aes-key --scheme with v1 security warning; handler reads scheme`
+
+---
+
+### Task 4: `rotate-key` preserves the filter's scheme
+
+**Files:**
+- Modify: `src/git_secret_protector/services/key_rotator.py`
+- Test: `tests/unit/` (key rotator tests / `test_encryption_manager.py` rotate tests)
+
+**Interfaces:**
+- `KeyRotator.rotate_key` reads `get_scheme(filter_name)` before rotation; writes the new key blob with the same scheme and re-encrypts using a handler built with that scheme.
+
+- [ ] **Step 1: Failing test** - rotating a v1 filter keeps scheme v1: mock key_manager so `get_scheme -> "v1"`; assert the new-key setup is called with `scheme="v1"` (or that set_scheme/setup writes version 1) and the encryption handler used for re-encrypt has scheme "v1". Mirror the existing rotate test structure.
+
+- [ ] **Step 2-4:** implement (read scheme; thread it through the new-key creation and the re-encrypt handler construction in key_rotator), run, full suite.
+
+  Note: inspect `key_rotator.py` rotate_key flow - it calls `retrieve_key_and_iv` then builds `AesEncryptionHandler(...)` twice (decrypt-old, encrypt-new). The encrypt-new handler must use the preserved scheme; the decrypt-old handler can stay default (decrypt is version-byte-authoritative). The new key's blob must be written with the preserved scheme.
+
+- [ ] **Step 5: commit** `fix(rotate): preserve filter encryption scheme across key rotation`
+
+---
+
+### Task 5: `upgrade-scheme <filter>` command
+
+**Files:**
+- Modify: `src/git_secret_protector/services/encryption_manager.py` (`upgrade_scheme`)
+- Modify: `src/git_secret_protector/main.py` (subcommand + handler)
+- Test: `tests/unit/test_encryption_manager.py`, `tests/unit/test_main_cli.py`
+
+**Interfaces:**
+- `EncryptionManager.upgrade_scheme(self, filter_name, assume_yes=False)`:
+  1. `scheme = key_manager.get_scheme(filter)`; if `"v2"` -> info "already on v2", JSON `{ok, command:"upgrade-scheme", filter, message, counts:{reencrypted:0,total:N}}`, return.
+  2. confirm-gate (EOF-safe, skip with assume_yes), mirror `rotate_keys`.
+  3. re-encrypt every matched file to v2: read each file, decrypt (version-byte handler), write back with a v2 handler; emit per-file progress (reuse the bulk progress pattern). Practically: temporarily get a v2 handler (build `AesEncryptionHandler(key, iv, magic_header, scheme="v2")`) and for each file: decrypt with a default handler then encrypt with the v2 handler, OR simpler: since files are v1 on disk, `decrypt_file` (version-byte) then `encrypt_file` with the v2 handler. Implement via the handler's per-file methods.
+  4. `key_manager.set_scheme(filter, "v2")` AFTER all files re-encrypted (fail-safe ordering).
+  5. verify-after: every matched file `__is_encrypted` and its post-magic byte == 0x02; on any failure -> error + sys.exit(1).
+  6. JSON envelope `{ok, command:"upgrade-scheme", filter, counts:{reencrypted, total}}`; human success line.
+- main: `upgrade-scheme` subparser with `filter_name` (nargs="?") + `-y/--yes`, `parents=[common]`; handler `upgrade_scheme(args)` calls `manager.upgrade_scheme(args.filter_name, assume_yes=args.yes)`. Apply `_require_filter`.
+
+- [ ] **Step 1: Failing tests**
+  - idempotent: get_scheme->"v2" -> no-op, returns, set_scheme NOT called, counts.reencrypted==0.
+  - v1->v2: get_scheme->"v1", two matched files; assume_yes=True; asserts files re-encrypted to v2 (mock handler/`__is_encrypted`), `set_scheme(filter,"v2")` called AFTER re-encryption, JSON counts.reencrypted==2.
+  - decline: assume_yes=False, input raises EOFError -> aborts, set_scheme NOT called, no re-encryption.
+  - verify-after failure -> sys.exit(1) (simulate a file still v1 after re-encrypt).
+- [ ] **Step 2-4:** implement, run, full suite.
+- [ ] **Step 5: commit** `feat(cli): upgrade-scheme command for one-way v1->v2 migration`
+
+---
+
+### Task 6: Surface scheme in `status` and `doctor`
+
+**Files:**
+- Modify: `src/git_secret_protector/services/encryption_manager.py` (`status`, `doctor`)
+- Test: `tests/unit/test_encryption_manager.py`
+
+**Interfaces:**
+- `status`: each filter dict gains `"scheme": get_scheme(name)`; human adds a `  scheme: <s>` line under the `Filter:` header. (Wrap get_scheme in try/except -> default "v2" or omit on read error, so status never crashes.)
+- `doctor`: per filter add a check `{"check": "scheme", "status": "ok"|"warn", "detail": ..., "filter": name}` - v2 ok, v1 warn. Human render via the existing label map.
+
+- [ ] **Step 1: Failing tests**
+  - status json: filter has `scheme` field (patch get_scheme).
+  - status human: `  scheme: v1` line present for a v1 filter; existing status assertions unchanged.
+  - doctor json: a v1 filter yields a scheme check with status "warn" and a `filter` key; v2 yields "ok".
+  - doctor human: v1 filter prints a `[WARN]` scheme line; existing doctor substring assertions unchanged; exit code semantics unchanged (a v1 warn does NOT make doctor return 1 - only plaintext does).
+- [ ] **Step 2-4:** implement (build into the existing status/doctor dict-then-fork structure from the prior feature), run, full suite.
+- [ ] **Step 5: commit** `feat(status,doctor): surface per-filter encryption scheme (v1 flagged warn)`
+
+---
+
+### Task 7: README documentation
+
+**Files:** Modify `README.md`
+
+- [ ] Document `setup-aes-key --scheme {v1,v2}` (with the v1 = unauthenticated-legacy security note), `upgrade-scheme <filter>`, and that status/doctor now show the scheme. Match existing heading style; plain hyphens only; no emojis.
+- [ ] Commit `docs: document encryption scheme versioning (setup --scheme, upgrade-scheme)`
+
+---
+
+## Self-Review
+
+**Spec coverage:** scheme-in-blob (T2), scheme-aware encrypt with v1 reintroduced (T1), handler wiring + setup --scheme + warning (T3), rotate preserves scheme (T4), upgrade-scheme one-way migration (T5), status/doctor surfacing with v1 warn (T6), docs (T7). Decrypt left version-byte-authoritative (untouched across all tasks). Guard-rail stdout-purity test untouched.
+
+**Type consistency:** scheme is the string `"v1"`/`"v2"` everywhere at the service layer; the key blob stores int `version` 1/2; `get_scheme`/`set_scheme` are the only translation boundary. `AesEncryptionHandler(scheme=...)` default `"v2"`.
+
+**Security:** v1 paths are warned at setup (T3), flagged warn in doctor/status (T6), documented as a security caveat (T7, PR body). v1 reintroduction is encrypt-only; decrypt already supported v1.
+
+**Release:** version bump + publish are NOT in this plan (held for go-ahead). Do not edit pyproject version or CHANGELOG.

--- a/docs/specs/encryption-versioning/2026-06-22-scheme-versioning-design.md
+++ b/docs/specs/encryption-versioning/2026-06-22-scheme-versioning-design.md
@@ -1,0 +1,174 @@
+# Encryption scheme versioning for backward compatibility
+
+Status: approved design (direction confirmed; ships as a minor release)
+Date: 2026-06-22
+
+## Goal
+
+Let v1.2.x clients (which only understand the legacy unauthenticated AES-CBC scheme) and
+v1.4.0+ clients (authenticated AES-CTR + HMAC, "v2") coexist on the same repo. Make the
+encryption scheme a property of the stored key blob:
+
+- New keys default to authenticated **v2**.
+- `setup-aes-key --scheme v1` opts a filter down to the legacy scheme for repos that still
+  have un-upgradeable old clients.
+- `upgrade-scheme <filter>` performs a one-way v1 -> v2 migration (confirm-gated,
+  idempotent, verify-after; no runtime downgrade).
+- `status` / `doctor` surface the active scheme; v1 is flagged as a security warning.
+
+## Versioning decision
+
+This is **additive** and ships as a **minor** release (1.5.0), not 2.0.0. Existing v2 users
+see no behavior change (v2 remains the default; decrypt already reads both formats). The
+ticket's "2.0.0" framing predates the finding that nothing breaks. The actual release is
+triggered separately and is out of scope for the implementation PR.
+
+## Security framing (dominant constraint)
+
+`--scheme v1` deliberately reintroduces **unauthenticated, fixed-IV AES-CBC** - the scheme
+v2 was built to replace. This downgrade must be loud, never silent:
+
+- `setup-aes-key --scheme v1` prints a security warning to stderr.
+- `doctor` reports a v1 filter as `[WARN]` (status `warn`), not `[ OK ]`.
+- `status` surfaces the scheme per filter.
+- The PR description and commit messages carry the security caveat (the release CHANGELOG
+  is auto-generated from git log by the release workflow; do not hand-edit CHANGELOG).
+
+## Architecture
+
+### Decrypt stays version-byte-authoritative (unchanged)
+
+`AesEncryptionHandler._perform_decryption` already dispatches on the file's wire bytes:
+a `0x02` version byte after the magic header => v2 (CTR+HMAC); otherwise => v1 (CBC).
+This is independent of the key blob's scheme, so a v2 key blob still decrypts on-disk v1
+files mid-migration. Do not couple decrypt to the blob scheme.
+
+### Encrypt becomes scheme-driven
+
+`AesEncryptionHandler` gains a `scheme` parameter (default `"v2"`), and `_perform_encryption`
+branches on it:
+
+- `scheme == "v2"` (default): current behavior - `magic_header + 0x02 + base64(iv||ct||tag)`,
+  content-derived IV, HKDF subkeys, AES-256-CTR, encrypt-then-HMAC.
+- `scheme == "v1"`: legacy CBC - `magic_header + base64(AES-CBC(pad(plaintext), aes_key, iv))`
+  using the **stored** iv (fixed, so identical plaintext -> identical ciphertext, preserving
+  git determinism). No `0x02` version byte (the decrypt v1 path is the no-version-byte branch).
+  The already-encrypted short-circuit (`data.startswith(magic_header) -> return data`) applies
+  to both schemes.
+
+Default `scheme="v2"` keeps every existing constructor call site working unchanged
+(`key_rotator.py`, tests).
+
+### Scheme stored in the key blob
+
+The blob already contains `"version": 2`. Reuse it as the authoritative **encrypt** scheme
+selector (values `1` or `2`); do not add a redundant key.
+
+- `AesKeyManager.setup_aes_key_and_iv(filter_name, scheme="v2")` writes
+  `"version": 2` or `1` accordingly.
+- New method `AesKeyManager.get_scheme(filter_name) -> "v1" | "v2"`: reads the blob (cache
+  first, same path as `retrieve_key_and_iv`), maps `version` 1->"v1", 2/absent->"v2"
+  (absent defaults to v2: a 1.4.0-written blob always has it; only hypothetical hand-written
+  blobs would lack it, and v2 is the safe authenticated default).
+- New method `AesKeyManager.set_scheme(filter_name, scheme)`: rewrites the stored blob's
+  `version` field (used by `upgrade-scheme`), preserving `aes_key`/`iv`, in both storage
+  backend and local cache.
+
+A 1.2.4 client ignores the `version` field and always does CBC; that is exactly correct for
+a v1-scheme filter (files are CBC) and is the incompatibility we are fixing for v2-scheme
+filters (don't point old clients at v2 filters).
+
+### Handler construction reads the scheme
+
+`EncryptionManager.__get_encryption_handler(filter_name)` passes the scheme:
+
+```python
+def __get_encryption_handler(self, filter_name):
+    aes_key, iv = self.key_manager.retrieve_key_and_iv(filter_name)
+    scheme = self.key_manager.get_scheme(filter_name)
+    return AesEncryptionHandler(aes_key=aes_key, iv=iv,
+                                magic_header=self.magic_header, scheme=scheme)
+```
+
+`retrieve_key_and_iv`'s `(key, iv)` signature is unchanged (key_rotator keeps working).
+
+## Commands
+
+### `setup-aes-key --scheme {v1,v2}`
+
+Default `v2`. Add `--scheme` to the subparser. `EncryptionManager.setup_aes_key` gains a
+`scheme="v2"` param, passed to `key_manager.setup_aes_key_and_iv`. On `v1`, emit a security
+warning via `self.output.error(...)` (stderr) before the success line, e.g.
+`"WARNING: filter '<f>' uses the legacy v1 scheme (unauthenticated AES-CBC). Use only for
+repos with pre-1.4.0 clients; run 'upgrade-scheme <f>' once they are upgraded."`
+JSON envelope success includes `"scheme": "v1"`.
+
+### `rotate-key` preserves the filter's scheme
+
+`KeyRotator.rotate_key` currently generates a new key and re-encrypts. It must preserve the
+existing filter scheme: read `get_scheme(filter_name)` before rotation; the new key blob is
+written with the same scheme, and re-encryption uses a handler constructed with that scheme.
+(Without this, rotating a v1 filter would silently upgrade it to v2 and break old clients.)
+
+### `upgrade-scheme <filter>`
+
+One-way v1 -> v2 migration:
+
+1. `scheme = get_scheme(filter)`. If already `v2`: print idempotent no-op message
+   (`"Filter '<f>' is already on scheme v2; nothing to do."`), return 0.
+2. Confirm-gate (skip with `-y/--yes`), EOF-safe decline (mirror `rotate_keys`):
+   `"Upgrade filter '<f>' from v1 to v2? This re-encrypts ALL matched files. [y/N] "`.
+3. Re-encrypt every matched file to v2: decrypt with the v1 handler (or rely on
+   version-byte decrypt), then write back with a v2 handler. Reuse the existing per-file
+   bulk path with progress.
+4. `set_scheme(filter, "v2")` AFTER all files are re-encrypted (fail-safe ordering: a crash
+   mid-run leaves version=1 and a mix of v1/v2 files, all still decryptable by version byte).
+5. Verify-after: assert every matched file is now v2-encrypted (`__is_encrypted` and the
+   version byte == 0x02); on mismatch, error + nonzero exit.
+6. No downgrade path (no v2 -> v1).
+   JSON envelope: `{ok, command:"upgrade-scheme", filter, counts:{reencrypted,total}}`.
+
+### `status` / `doctor` surface the scheme
+
+- `status` JSON: each filter object gains `"scheme": "v1"|"v2"`. Human output adds a
+  `  scheme: v1|v2` line under each `Filter:` header.
+- `doctor`: add a per-filter scheme check `{check:"scheme.<filter>", status, detail, filter}`
+  - `v2` -> status `ok`, detail `"filter '<f>' uses authenticated scheme v2"`.
+  - `v1` -> status `warn`, detail `"filter '<f>' uses legacy unauthenticated scheme v1
+    (run upgrade-scheme once all clients are >=1.4.0)"`.
+  Human render uses the existing `[ OK ]`/`[WARN]` label mapping.
+
+## Affected files
+
+- `src/git_secret_protector/crypto/aes_encryption_handler.py` - `scheme` param + v1 encrypt branch.
+- `src/git_secret_protector/crypto/aes_key_manager.py` - `setup_aes_key_and_iv(scheme=...)`,
+  `get_scheme`, `set_scheme`.
+- `src/git_secret_protector/services/encryption_manager.py` - pass scheme to handler;
+  `setup_aes_key(scheme=...)` + warning; `upgrade_scheme`; status/doctor scheme surfacing.
+- `src/git_secret_protector/services/key_rotator.py` - preserve scheme across rotation.
+- `src/git_secret_protector/main.py` - `--scheme` on setup-aes-key; `upgrade-scheme` subcommand.
+- Tests across `tests/unit/`.
+
+## Testing
+
+- Handler: v1 encrypt round-trips through v1 decrypt; v1 ciphertext is deterministic for the
+  same plaintext; v2 path unchanged; the magic-header short-circuit holds for both.
+- Cross-scheme: a v1-encrypted file decrypts, and the decrypt path is selected by the wire
+  byte regardless of blob scheme.
+- key_manager: setup with scheme v1 writes version 1; get_scheme maps version<->scheme and
+  defaults absent->v2; set_scheme rewrites version preserving key/iv (cache + backend).
+- setup-aes-key --scheme v1 emits the stderr warning and the JSON scheme field.
+- rotate-key on a v1 filter keeps scheme v1 (new blob version 1; re-encrypted files are v1).
+- upgrade-scheme: idempotent no-op on v2; v1->v2 re-encrypts all files, sets version 2,
+  verify-after passes; EOF/decline aborts without changing files or blob; crash-safety
+  ordering (blob updated last) is exercised by asserting files are v2 before the blob flip is
+  observable, or by unit-testing the ordering.
+- status/doctor: scheme surfaced in JSON and human; v1 -> doctor warn (not ok).
+- Guard-rail (existing): encrypt/decrypt filter stdout stays pure bytes - must still pass.
+
+Test command: `poetry run pytest tests/unit/`.
+
+## Out of scope
+
+- The 1.5.0 release trigger (held for explicit go-ahead; irreversible PyPI publish).
+- #1981 (CI image bump) - separate ticket, credential-blocked.

--- a/src/git_secret_protector/crypto/aes_encryption_handler.py
+++ b/src/git_secret_protector/crypto/aes_encryption_handler.py
@@ -14,12 +14,15 @@ logger = logging.getLogger(__name__)
 class AesEncryptionHandler:
     V2 = b"\x02"
 
-    def __init__(self, aes_key: bytes, iv: bytes, magic_header: bytes):
+    def __init__(
+        self, aes_key: bytes, iv: bytes, magic_header: bytes, scheme: str = "v2"
+    ):
         if aes_key is None or iv is None:
             raise ValueError("AES key and IV must not be None")
         self.aes_key = aes_key
         self.iv = iv
         self.magic_header = magic_header
+        self.scheme = scheme
         self._enc_key = HKDF(aes_key, 32, b"", SHA256, 1, context=b"gsp:enc:v2")
         self._mac_key = HKDF(aes_key, 32, b"", SHA256, 1, context=b"gsp:mac:v2")
         self._iv_key = HKDF(aes_key, 32, b"", SHA256, 1, context=b"gsp:iv:v2")
@@ -63,7 +66,19 @@ class AesEncryptionHandler:
         if data.startswith(self.magic_header):
             logger.info("Data already contains MAGIC_HEADER. Skipping encryption.")
             return data
+        if self.scheme == "v1":
+            return self._encrypt_v1(data)
+        return self._encrypt_v2(data)
 
+    def _encrypt_v1(self, data: bytes) -> bytes:
+        # Legacy AES-256-CBC with fixed stored IV - deterministic for git filter stability
+        ciphertext = AES.new(self.aes_key, AES.MODE_CBC, self.iv).encrypt(
+            pad(data, AES.block_size)
+        )
+        return self.magic_header + base64.b64encode(ciphertext)
+
+    def _encrypt_v2(self, data: bytes) -> bytes:
+        # Authenticated AES-256-CTR with content-derived IV + HMAC-SHA256 tag
         iv = HMAC.new(self._iv_key, data, SHA256).digest()[:16]
         ctr = Counter.new(128, initial_value=int.from_bytes(iv, "big"))
         ciphertext = AES.new(self._enc_key, AES.MODE_CTR, counter=ctr).encrypt(data)
@@ -85,7 +100,7 @@ class AesEncryptionHandler:
                 HMAC.new(self._mac_key, iv + ciphertext, SHA256).verify(tag)
             except ValueError as e:
                 raise ValueError(
-                    "Authentication failed — wrong key or tampered ciphertext"
+                    "Authentication failed - wrong key or tampered ciphertext"
                 ) from e
 
             ctr = Counter.new(128, initial_value=int.from_bytes(iv, "big"))

--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -42,7 +42,7 @@ class AesKeyManager:
     :raises AesKeyError: If there is any error during the setup process
     """
 
-    def setup_aes_key_and_iv(self, filter_name: str):
+    def setup_aes_key_and_iv(self, filter_name: str, scheme: str = "v2"):
         try:
             logger.info("Set up AES key and IV for filter: %s", filter_name)
 
@@ -62,7 +62,7 @@ class AesKeyManager:
             data = {
                 "aes_key": base64.b64encode(s=aes_key).decode(encoding="utf-8"),
                 "iv": base64.b64encode(s=iv).decode(encoding="utf-8"),
-                "version": 2,
+                "version": 1 if scheme == "v1" else 2,
             }
             json_data = json.dumps(obj=data)
 
@@ -145,7 +145,7 @@ class AesKeyManager:
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
             0o600,
         )
-        # Lock mode to 0600 on the fd before writing — O_CREAT ignores the mode
+        # Lock mode to 0600 on the fd before writing - O_CREAT ignores the mode
         # for a pre-existing file, so without this the secret would briefly land
         # under the old (e.g. 0644) permissions.
         os.fchmod(cache_fd, 0o600)
@@ -164,6 +164,42 @@ class AesKeyManager:
 
         logger.debug("No local cache found for filter: %s", filter_name)
         return None
+
+    def get_scheme(self, filter_name: str) -> str:
+        """Return "v1" or "v2" for the scheme stored in the key blob.
+
+        Tries the local cache first; falls back to the storage backend.
+        A missing or unrecognised version field defaults to "v2" (safe default).
+        A completely missing key blob still raises AesKeyError (same as retrieve_key_and_iv).
+        """
+        try:
+            data = self.load_key_iv_from_cache(filter_name=filter_name)
+            if data is None:
+                parameter_name = self._parameter_name(filter_name=filter_name)
+                data = json.loads(
+                    self._get_storage_manager().retrieve(name=parameter_name)
+                )
+            version = data.get("version", 2)
+            return "v1" if version == 1 else "v2"
+        except Exception as e:
+            raise AesKeyError(
+                f"Failed to get scheme for filter '{filter_name}': {str(e)}"
+            )
+
+    def set_scheme(self, filter_name: str, scheme: str):
+        """Rewrite the version field in the stored blob (backend + cache) without touching aes_key/iv."""
+        try:
+            parameter_name = self._parameter_name(filter_name=filter_name)
+            # Backend is authoritative - always reload from there
+            data = json.loads(self._get_storage_manager().retrieve(name=parameter_name))
+            data["version"] = 2 if scheme == "v2" else 1
+            json_data = json.dumps(data)
+            self._get_storage_manager().store(parameter_name, json_data)
+            self.cache_key_iv_locally(filter_name, json_data)
+        except Exception as e:
+            raise AesKeyError(
+                f"Failed to set scheme for filter '{filter_name}': {str(e)}"
+            )
 
     def remove_key_iv_from_cache(self, filter_name: str):
         cache_path = self._cache_path(filter_name=filter_name)

--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -192,7 +192,7 @@ class AesKeyManager:
             parameter_name = self._parameter_name(filter_name=filter_name)
             # Backend is authoritative - always reload from there
             data = json.loads(self._get_storage_manager().retrieve(name=parameter_name))
-            data["version"] = 2 if scheme == "v2" else 1
+            data["version"] = 1 if scheme == "v1" else 2
             json_data = json.dumps(data)
             self._get_storage_manager().store(parameter_name, json_data)
             self.cache_key_iv_locally(filter_name, json_data)

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -81,6 +81,12 @@ def rotate_key(args):
     manager.rotate_keys(filter_name=filter_name, assume_yes=getattr(args, "yes", False))
 
 
+def upgrade_scheme(args):
+    manager.upgrade_scheme(
+        filter_name=args.filter_name, assume_yes=getattr(args, "yes", False)
+    )
+
+
 def decrypt_stdin(args):
     file_name = args.file_name
     manager.decrypt_stdin(file_name=file_name)
@@ -270,6 +276,22 @@ def main():
         help="Skip the rotate confirmation prompt",
     )
     parser_rotate_key.set_defaults(func=rotate_key)
+
+    parser_upgrade_scheme = subparsers.add_parser(
+        "upgrade-scheme",
+        help="One-way upgrade of a filter from v1 (legacy AES-CBC) to v2 (AES-256-CTR+HMAC)",
+        parents=[common],
+    )
+    parser_upgrade_scheme.add_argument(
+        "filter_name", type=str, nargs="?", help="The filter name"
+    )
+    parser_upgrade_scheme.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip the upgrade confirmation prompt",
+    )
+    parser_upgrade_scheme.set_defaults(func=upgrade_scheme)
 
     # Status command
     parser_status = subparsers.add_parser(

--- a/src/git_secret_protector/main.py
+++ b/src/git_secret_protector/main.py
@@ -64,7 +64,7 @@ def init_module_folder():
 
 def setup_aes_key(args):
     filter_name = args.filter_name
-    manager.setup_aes_key(filter_name=filter_name)
+    manager.setup_aes_key(filter_name=filter_name, scheme=args.scheme)
 
 
 def setup_filters(_):
@@ -191,9 +191,23 @@ def main():
     )
     subparsers = parser.add_subparsers(help="Available commands")
 
+    # setup-aes-key has its own subparser (--scheme flag)
+    parser_setup_aes_key = subparsers.add_parser(
+        "setup-aes-key", help="Set up AES key for a filter", parents=[common]
+    )
+    parser_setup_aes_key.add_argument(
+        "filter_name", type=str, nargs="?", help="The filter name"
+    )
+    parser_setup_aes_key.add_argument(
+        "--scheme",
+        choices=["v1", "v2"],
+        default="v2",
+        help="Encryption scheme (default: v2; v1 is legacy AES-CBC)",
+    )
+    parser_setup_aes_key.set_defaults(func=setup_aes_key)
+
     # Add filter commands to the parser
     filter_commands = [
-        ("setup-aes-key", setup_aes_key, "Set up AES key for a filter"),
         ("pull-aes-key", pull_aes_key, "Pull AES key for a filter"),
         (
             "decrypt-files",

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -357,10 +357,8 @@ class EncryptionManager:
             v2_handler.decrypt_file(file)
             v2_handler.encrypt_file(file)
 
-        # Fail-safe: update scheme metadata only after all blobs are v2
-        self.key_manager.set_scheme(filter_name, "v2")
-
-        # Verify-after: each file must be encrypted and have the v2 version byte
+        # Verify-after: each file must be encrypted and have the v2 version byte.
+        # set_scheme is called only after this passes so the blob stays v1 on failure.
         v2_byte = AesEncryptionHandler.V2
         failed_files = []
         for file in files:
@@ -390,6 +388,9 @@ class EncryptionManager:
                 )
             )
             sys.exit(1)
+
+        # Fail-safe: flip the blob to v2 only after all files are verified v2.
+        self.key_manager.set_scheme(filter_name, "v2")
 
         msg = f"Successfully upgraded filter '{filter_name}' to scheme v2"
         self.output.info(msg)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -487,7 +487,15 @@ class EncryptionManager:
                     {"path": f, "encrypted": self.__is_encrypted(file_path=f)}
                     for f in files
                 ]
-                data["filters"].append({"name": filter_name, "files": file_entries})
+                try:
+                    scheme = self.key_manager.get_scheme(filter_name)
+                    if scheme not in ("v1", "v2"):
+                        scheme = "v2"
+                except Exception:
+                    scheme = "v2"
+                data["filters"].append(
+                    {"name": filter_name, "files": file_entries, "scheme": scheme}
+                )
 
             if self.output.json:
                 self.output.result(data)
@@ -495,6 +503,7 @@ class EncryptionManager:
 
             for entry in data["filters"]:
                 print(f"Filter: {entry['name']}")
+                print(f"  scheme: {entry['scheme']}")
                 if entry["files"]:
                     for f in entry["files"]:
                         status = "Encrypted" if f["encrypted"] else "⚠ PLAINTEXT"
@@ -613,6 +622,35 @@ class EncryptionManager:
                         "check": "key_cache",
                         "status": "warn",
                         "detail": f"no local key cache for '{filter_name}' (run pull-aes-key)",
+                        "filter": filter_name,
+                    }
+                )
+
+        for filter_name in filter_names:
+            try:
+                scheme = self.key_manager.get_scheme(filter_name)
+                if scheme not in ("v1", "v2"):
+                    scheme = "v2"
+            except Exception:
+                scheme = "v2"
+            if scheme == "v2":
+                checks.append(
+                    {
+                        "check": "scheme",
+                        "status": "ok",
+                        "detail": f"filter '{filter_name}' uses authenticated scheme v2",
+                        "filter": filter_name,
+                    }
+                )
+            else:
+                checks.append(
+                    {
+                        "check": "scheme",
+                        "status": "warn",
+                        "detail": (
+                            f"filter '{filter_name}' uses legacy unauthenticated scheme v1 "
+                            f"(run upgrade-scheme once all clients are >=1.4.0)"
+                        ),
                         "filter": filter_name,
                     }
                 )

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -315,6 +315,92 @@ class EncryptionManager:
             sys.stdout.buffer.write(encrypted_data)
             sys.stdout.buffer.flush()
 
+    def upgrade_scheme(self, filter_name: str, assume_yes: bool = False):
+        filter_name = self._require_filter(filter_name)
+        scheme = self.key_manager.get_scheme(filter_name)
+        files = self.git_attributes_parser.get_files_for_filter(filter_name)
+        total = len(files)
+
+        if scheme == "v2":
+            msg = f"Filter '{filter_name}' is already on scheme v2; nothing to do."
+            self.output.info(msg)
+            self.output.result(
+                self._envelope_ok(
+                    "upgrade-scheme",
+                    filter=filter_name,
+                    message=msg,
+                    counts={"reencrypted": 0, "total": total},
+                )
+            )
+            return
+
+        if not assume_yes:
+            try:
+                answer = input(
+                    f"Upgrade filter '{filter_name}' from v1 to v2? "
+                    f"This re-encrypts ALL matched files. [y/N] "
+                )
+            except EOFError:
+                answer = ""
+            if answer.strip().lower() not in {"y", "yes"}:
+                self.output.error("Aborted.")
+                return
+
+        aes_key, iv = self.key_manager.retrieve_key_and_iv(filter_name)
+        v2_handler = AesEncryptionHandler(
+            aes_key=aes_key, iv=iv, magic_header=self.magic_header, scheme="v2"
+        )
+
+        for i, file in enumerate(files, 1):
+            self.output.progress(f"[{i}/{total}] {file}")
+            v2_handler.decrypt_file(file)
+            v2_handler.encrypt_file(file)
+
+        # Fail-safe: update scheme metadata only after all blobs are v2
+        self.key_manager.set_scheme(filter_name, "v2")
+
+        # Verify-after: each file must be encrypted and have the v2 version byte
+        v2_byte = AesEncryptionHandler.V2
+        failed_files = []
+        for file in files:
+            if not self.__is_encrypted(file):
+                failed_files.append(file)
+                continue
+            try:
+                with open(file, "rb") as fh:
+                    fh.read(len(self.magic_header))  # skip magic header
+                    byte = fh.read(1)
+                if byte != v2_byte:
+                    failed_files.append(file)
+            except IOError:
+                failed_files.append(file)
+
+        if failed_files:
+            self.output.error(
+                f"upgrade-scheme: verify failed - {len(failed_files)} file(s) "
+                f"not v2 after re-encryption: {failed_files}"
+            )
+            self.output.result(
+                self._envelope_err(
+                    "upgrade-scheme",
+                    "verify-after failed",
+                    filter=filter_name,
+                    failed_files=failed_files,
+                )
+            )
+            sys.exit(1)
+
+        msg = f"Successfully upgraded filter '{filter_name}' to scheme v2"
+        self.output.info(msg)
+        self.output.result(
+            self._envelope_ok(
+                "upgrade-scheme",
+                filter=filter_name,
+                message=msg,
+                counts={"reencrypted": total, "total": total},
+            )
+        )
+
     def rotate_keys(self, filter_name: str, assume_yes: bool = False):
         filter_name = self._require_filter(filter_name)
         self._print_context(filter_name)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -317,6 +317,7 @@ class EncryptionManager:
 
     def upgrade_scheme(self, filter_name: str, assume_yes: bool = False):
         filter_name = self._require_filter(filter_name)
+        self._print_context(filter_name)
         scheme = self.key_manager.get_scheme(filter_name)
         files = self.git_attributes_parser.get_files_for_filter(filter_name)
         total = len(files)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -73,17 +73,25 @@ class EncryptionManager:
         self.output.error(f"Error: {msg}")
         sys.exit(1)
 
-    def setup_aes_key(self, filter_name: str):
+    def setup_aes_key(self, filter_name: str, scheme: str = "v2"):
         filter_name = self._require_filter(filter_name)
         self._print_context(filter_name)
         try:
             logger.info("Setting up AES key for filter: %s", filter_name)
-            self.key_manager.setup_aes_key_and_iv(filter_name)
+            self.key_manager.setup_aes_key_and_iv(filter_name, scheme=scheme)
             logger.info("Successfully set up AES key for filter: %s", filter_name)
+            if scheme == "v1":
+                self.output.error(
+                    f"WARNING: filter '{filter_name}' uses the legacy v1 scheme "
+                    f"(unauthenticated AES-CBC). Use only for repos with pre-1.4.0 "
+                    f"clients; run 'upgrade-scheme {filter_name}' once they are upgraded."
+                )
             msg = f"Successfully set up AES key for filter: {filter_name}"
             self.output.info(msg)
             self.output.result(
-                self._envelope_ok("setup-aes-key", filter=filter_name, message=msg)
+                self._envelope_ok(
+                    "setup-aes-key", filter=filter_name, scheme=scheme, message=msg
+                )
             )
         except Exception as e:
             logger.error(f"AES key setup command failed: {e}", exc_info=True)
@@ -767,8 +775,9 @@ class EncryptionManager:
 
     def __get_encryption_handler(self, filter_name: str):
         aes_key, iv = self.key_manager.retrieve_key_and_iv(filter_name)
+        scheme = self.key_manager.get_scheme(filter_name)
         return AesEncryptionHandler(
-            aes_key=aes_key, iv=iv, magic_header=self.magic_header
+            aes_key=aes_key, iv=iv, magic_header=self.magic_header, scheme=scheme
         )
 
     def __is_encrypted(self, file_path: str):

--- a/src/git_secret_protector/services/key_rotator.py
+++ b/src/git_secret_protector/services/key_rotator.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 class KeyRotator:
     @injector.inject
-    def __init__(self, key_manager: AesKeyManager, git_attributes_parser: GitAttributesParser):
+    def __init__(
+        self, key_manager: AesKeyManager, git_attributes_parser: GitAttributesParser
+    ):
         self.aes_key_manager = key_manager
         self.git_attributes_parser = git_attributes_parser
         self.magic_header = get_settings().magic_header.encode()
@@ -21,27 +23,52 @@ class KeyRotator:
         try:
             logger.info("Starting key and IV rotation for filter: %s", filter_name)
 
-            # Step 1: Retrieve the current AES key and IV
-            current_aes_key, current_iv = self.aes_key_manager.retrieve_key_and_iv(filter_name=filter_name)
+            # Step 1: Read the filter's scheme BEFORE any changes so rotation preserves it.
+            # A v1 filter must stay v1 after rotation; silently upgrading would break old clients.
+            scheme = self.aes_key_manager.get_scheme(filter_name)
 
-            # Step 2: Decrypt all files using the current AES key and IV
+            # Step 1b: Retrieve the current AES key and IV
+            current_aes_key, current_iv = self.aes_key_manager.retrieve_key_and_iv(
+                filter_name=filter_name
+            )
 
-            files_to_re_encrypt = self.git_attributes_parser.get_files_for_filter(filter_name=filter_name)
+            # Step 2: Decrypt all files using the current AES key and IV.
+            # Decryption is version-byte-authoritative (dispatches on the file's wire bytes),
+            # so no scheme override is needed here.
+            files_to_re_encrypt = self.git_attributes_parser.get_files_for_filter(
+                filter_name=filter_name
+            )
 
-            decryption_manager = AesEncryptionHandler(aes_key=current_aes_key, iv=current_iv, magic_header=self.magic_header)
+            decryption_manager = AesEncryptionHandler(
+                aes_key=current_aes_key, iv=current_iv, magic_header=self.magic_header
+            )
             decryption_manager.decrypt_files(files=files_to_re_encrypt)
 
-            # Step 3: Generate and store a new AES key and IV
-            self.aes_key_manager.setup_aes_key_and_iv(filter_name=filter_name)
+            # Step 3: Generate and store a new AES key and IV, preserving the filter's scheme.
+            self.aes_key_manager.setup_aes_key_and_iv(
+                filter_name=filter_name, scheme=scheme
+            )
 
             # Step 4: Retrieve the new AES key and IV
-            new_aes_key, new_iv = self.aes_key_manager.retrieve_key_and_iv(filter_name=filter_name)
+            new_aes_key, new_iv = self.aes_key_manager.retrieve_key_and_iv(
+                filter_name=filter_name
+            )
 
-            # Step 5: Encrypt all files using the new AES key and IV
-            encryption_manager = AesEncryptionHandler(aes_key=new_aes_key, iv=new_iv, magic_header=self.magic_header)
+            # Step 5: Encrypt all files using the new AES key and IV with the preserved scheme.
+            encryption_manager = AesEncryptionHandler(
+                aes_key=new_aes_key,
+                iv=new_iv,
+                magic_header=self.magic_header,
+                scheme=scheme,
+            )
             encryption_manager.encrypt_files(files=files_to_re_encrypt)
 
-            logger.info("Key and IV rotation and re-encryption complete for filter: %s", filter_name)
+            logger.info(
+                "Key and IV rotation and re-encryption complete for filter: %s",
+                filter_name,
+            )
         except Exception as e:
-            logger.error("Failed to rotate key and IV for filter %s: %s", filter_name, e)
+            logger.error(
+                "Failed to rotate key and IV for filter %s: %s", filter_name, e
+            )
             raise

--- a/tests/unit/test_aes_encryption_handler.py
+++ b/tests/unit/test_aes_encryption_handler.py
@@ -55,7 +55,7 @@ class TestAesEncryptionHandler(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Authentication failed — wrong key or tampered ciphertext",
+            "Authentication failed - wrong key or tampered ciphertext",
         ):
             self.handler.decrypt_data(tampered)
 
@@ -76,6 +76,52 @@ class TestAesEncryptionHandler(unittest.TestCase):
         already_encrypted = self.magic_header + b"\x02already-encrypted"
 
         self.assertIs(self.handler.encrypt_data(already_encrypted), already_encrypted)
+
+
+class TestAesEncryptionHandlerScheme(unittest.TestCase):
+    """Tests for scheme="v1"/"v2" parameter on AesEncryptionHandler."""
+
+    MH = b"ENCRYPTED"
+
+    def _h(self, scheme):
+        return AesEncryptionHandler(
+            aes_key=secrets.token_bytes(32),
+            iv=secrets.token_bytes(16),
+            magic_header=self.MH,
+            scheme=scheme,
+        )
+
+    def test_v1_roundtrip_and_deterministic(self):
+        h = self._h("v1")
+        data = b"super-secret-value"
+        ct1 = h.encrypt_data(data)
+        ct2 = h.encrypt_data(data)
+        self.assertTrue(ct1.startswith(self.MH))
+        self.assertNotEqual(ct1[len(self.MH) : len(self.MH) + 1], b"\x02")
+        self.assertEqual(ct1, ct2)
+        self.assertEqual(h.decrypt_data(ct1), data)
+
+    def test_v2_still_default_and_authenticated(self):
+        h = self._h("v2")
+        data = b"abc"
+        ct = h.encrypt_data(data)
+        self.assertEqual(ct[len(self.MH) : len(self.MH) + 1], b"\x02")
+        self.assertEqual(h.decrypt_data(ct), data)
+
+    def test_scheme_defaults_to_v2(self):
+        h = AesEncryptionHandler(
+            aes_key=secrets.token_bytes(32),
+            iv=secrets.token_bytes(16),
+            magic_header=self.MH,
+        )
+        self.assertEqual(h.encrypt_data(b"x")[len(self.MH) : len(self.MH) + 1], b"\x02")
+
+    def test_magic_header_short_circuit_both_schemes(self):
+        for s in ("v1", "v2"):
+            with self.subTest(scheme=s):
+                h = self._h(s)
+                already = self.MH + b"whatever"
+                self.assertIs(h.encrypt_data(already), already)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_aes_key_manager.py
+++ b/tests/unit/test_aes_key_manager.py
@@ -299,6 +299,42 @@ class TestAesKeyManagerScheme(unittest.TestCase):
         stored_json = self.mock_storage_manager.store.call_args[0][1]
         self.assertEqual(json.loads(stored_json)["version"], 1)
 
+    def test_set_scheme_v1_writes_version_1(self):
+        """set_scheme('v1') stores version 1 in backend (locks the mapping)."""
+        filter_name = secrets.token_hex(8)
+        original_blob = self._make_blob(version=2)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.retrieve.return_value = json.dumps(original_blob)
+
+        self.aes_key_manager.set_scheme(filter_name, "v1")
+
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        self.assertEqual(json.loads(stored_json)["version"], 1)
+
+    def test_set_scheme_v2_writes_version_2(self):
+        """set_scheme('v2') stores version 2 in backend (locks the mapping)."""
+        filter_name = secrets.token_hex(8)
+        original_blob = self._make_blob(version=1)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.retrieve.return_value = json.dumps(original_blob)
+
+        self.aes_key_manager.set_scheme(filter_name, "v2")
+
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        self.assertEqual(json.loads(stored_json)["version"], 2)
+
+    def test_set_scheme_unknown_defaults_to_v2(self):
+        """set_scheme with an unrecognised string defaults to version 2 (safe default)."""
+        filter_name = secrets.token_hex(8)
+        original_blob = self._make_blob(version=1)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.retrieve.return_value = json.dumps(original_blob)
+
+        self.aes_key_manager.set_scheme(filter_name, "unknown")
+
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        self.assertEqual(json.loads(stored_json)["version"], 2)
+
     def test_set_scheme_updates_local_cache(self):
         filter_name = secrets.token_hex(8)
         original_blob = self._make_blob(version=1)

--- a/tests/unit/test_aes_key_manager.py
+++ b/tests/unit/test_aes_key_manager.py
@@ -158,5 +158,160 @@ class TestAesKeyManager(unittest.TestCase):
         )
 
 
+class TestAesKeyManagerScheme(unittest.TestCase):
+    """Tests for scheme-aware key blob methods: setup(scheme), get_scheme, set_scheme."""
+
+    @patch("git_secret_protector.crypto.aes_key_manager.get_settings")
+    @patch("git_secret_protector.crypto.aes_key_manager.StorageManagerFactory.create")
+    def setUp(self, mock_create, mock_get_settings):
+        self.mock_settings = MagicMock()
+        self.mock_temp_dir = tempfile.TemporaryDirectory()
+        self.mock_settings.cache_dir = self.mock_temp_dir.name
+        self.mock_settings.module_name = secrets.token_hex(8)
+        self.mock_settings.storage_type = StorageType.AWS_SSM
+
+        mock_get_settings.return_value = self.mock_settings
+
+        self.mock_storage_manager = MagicMock()
+        mock_create.return_value = self.mock_storage_manager
+
+        self.aes_key_manager = AesKeyManager()
+        # Give the manager a pre-wired storage manager so _get_storage_manager() returns it
+        self.aes_key_manager.storage_manager = self.mock_storage_manager
+
+    def _make_blob(self, version=2):
+        aes_key = base64.b64encode(secrets.token_bytes(32)).decode("utf-8")
+        iv = base64.b64encode(secrets.token_bytes(16)).decode("utf-8")
+        data = {"aes_key": aes_key, "iv": iv}
+        if version is not None:
+            data["version"] = version
+        return data
+
+    # ------------------------------------------------------------------
+    # setup_aes_key_and_iv scheme tests
+    # ------------------------------------------------------------------
+
+    def test_setup_default_scheme_writes_version_2(self):
+        filter_name = secrets.token_hex(8)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.exists.return_value = False
+
+        self.aes_key_manager.setup_aes_key_and_iv(filter_name)
+
+        self.mock_storage_manager.store.assert_called_once()
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        data = json.loads(stored_json)
+        self.assertEqual(data["version"], 2)
+
+    def test_setup_v1_scheme_writes_version_1(self):
+        filter_name = secrets.token_hex(8)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.exists.return_value = False
+
+        self.aes_key_manager.setup_aes_key_and_iv(filter_name, scheme="v1")
+
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        data = json.loads(stored_json)
+        self.assertEqual(data["version"], 1)
+
+    def test_setup_v2_scheme_writes_version_2(self):
+        filter_name = secrets.token_hex(8)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.exists.return_value = False
+
+        self.aes_key_manager.setup_aes_key_and_iv(filter_name, scheme="v2")
+
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        data = json.loads(stored_json)
+        self.assertEqual(data["version"], 2)
+
+    # ------------------------------------------------------------------
+    # get_scheme tests
+    # ------------------------------------------------------------------
+
+    def test_get_scheme_version_1_returns_v1(self):
+        filter_name = secrets.token_hex(8)
+        blob = self._make_blob(version=1)
+        # Write to cache so load_key_iv_from_cache finds it
+        self.aes_key_manager.cache_key_iv_locally(filter_name, json.dumps(blob))
+
+        result = self.aes_key_manager.get_scheme(filter_name)
+
+        self.assertEqual(result, "v1")
+
+    def test_get_scheme_version_2_returns_v2(self):
+        filter_name = secrets.token_hex(8)
+        blob = self._make_blob(version=2)
+        self.aes_key_manager.cache_key_iv_locally(filter_name, json.dumps(blob))
+
+        result = self.aes_key_manager.get_scheme(filter_name)
+
+        self.assertEqual(result, "v2")
+
+    def test_get_scheme_version_absent_defaults_v2(self):
+        filter_name = secrets.token_hex(8)
+        blob = self._make_blob(version=None)  # no "version" key
+        self.aes_key_manager.cache_key_iv_locally(filter_name, json.dumps(blob))
+
+        result = self.aes_key_manager.get_scheme(filter_name)
+
+        self.assertEqual(result, "v2")
+
+    def test_get_scheme_cache_miss_falls_back_to_backend(self):
+        filter_name = secrets.token_hex(8)
+        blob = self._make_blob(version=1)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.retrieve.return_value = json.dumps(blob)
+
+        result = self.aes_key_manager.get_scheme(filter_name)
+
+        self.mock_storage_manager.retrieve.assert_called_once()
+        self.assertEqual(result, "v1")
+
+    # ------------------------------------------------------------------
+    # set_scheme tests
+    # ------------------------------------------------------------------
+
+    def test_set_scheme_v2_rewrites_version_preserving_key_iv(self):
+        filter_name = secrets.token_hex(8)
+        original_blob = self._make_blob(version=1)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.retrieve.return_value = json.dumps(original_blob)
+
+        self.aes_key_manager.set_scheme(filter_name, "v2")
+
+        # Backend store called with version 2
+        self.mock_storage_manager.store.assert_called_once()
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        stored = json.loads(stored_json)
+        self.assertEqual(stored["version"], 2)
+        self.assertEqual(stored["aes_key"], original_blob["aes_key"])
+        self.assertEqual(stored["iv"], original_blob["iv"])
+
+    def test_set_scheme_v1_rewrites_version(self):
+        filter_name = secrets.token_hex(8)
+        original_blob = self._make_blob(version=2)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.retrieve.return_value = json.dumps(original_blob)
+
+        self.aes_key_manager.set_scheme(filter_name, "v1")
+
+        stored_json = self.mock_storage_manager.store.call_args[0][1]
+        self.assertEqual(json.loads(stored_json)["version"], 1)
+
+    def test_set_scheme_updates_local_cache(self):
+        filter_name = secrets.token_hex(8)
+        original_blob = self._make_blob(version=1)
+        self.mock_storage_manager.parameter_name.return_value = f"/enc/{filter_name}"
+        self.mock_storage_manager.retrieve.return_value = json.dumps(original_blob)
+
+        self.aes_key_manager.set_scheme(filter_name, "v2")
+
+        # Cache should now reflect version 2
+        cached = self.aes_key_manager.load_key_iv_from_cache(filter_name)
+        self.assertIsNotNone(cached)
+        self.assertEqual(cached["version"], 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -1137,6 +1137,27 @@ class TestUpgradeScheme(unittest.TestCase):
         self.assertEqual(payload["counts"]["reencrypted"], 2)
         self.assertEqual(payload["counts"]["total"], 2)
 
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def test_upgrade_scheme_v1_calls_print_context(self, mock_get_settings):
+        """upgrade_scheme calls _print_context with the filter name on the v1->v2 path."""
+        mock_settings = MagicMock()
+        mock_settings.storage_type.value = "AWS_SSM"
+        mock_settings.module_name = "git-secret-protector"
+        mock_settings.base_dir = "/repo/root"
+        mock_get_settings.return_value = mock_settings
+
+        self.key_manager.get_scheme.return_value = "v1"
+        self.key_manager.retrieve_key_and_iv.return_value = (b"\x00" * 32, b"\x01" * 16)
+        self.git_attributes_parser.get_files_for_filter.return_value = []
+
+        with patch.object(self.manager, "_print_context") as mock_print_ctx:
+            # No files to re-encrypt; assume_yes skips the confirm prompt.
+            # set_scheme is called with no files - that's fine, we only care about
+            # _print_context being called before anything else.
+            self.manager.upgrade_scheme("secret", assume_yes=True)
+
+        mock_print_ctx.assert_called_once_with("secret")
+
     @patch("git_secret_protector.services.encryption_manager.AesEncryptionHandler")
     def test_verify_after_failure_exits_1(self, mock_handler_cls):
         """If post-upgrade verify finds a file not v2, sys.exit(1)."""

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -768,6 +768,111 @@ class TestEncryptionManagerService(unittest.TestCase):
             "[ OK ] all tracked secret files are encrypted for 'secret'", text
         )
 
+    # ----- Task-6 tests: scheme surfaced in status and doctor -----
+
+    def test_status_json_includes_scheme_field(self):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["enc.txt"]
+        self.key_manager.get_scheme.return_value = "v1"
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=True
+        ):
+            with contextlib.redirect_stdout(out):
+                self.manager.status()
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["filters"][0]["scheme"], "v1")
+
+    def test_status_human_includes_scheme_line_and_existing_lines_unchanged(self):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["enc.txt"]
+        self.key_manager.get_scheme.return_value = "v1"
+        out = io.StringIO()
+        with patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=True
+        ):
+            with contextlib.redirect_stdout(out):
+                self.manager.status()
+        text = out.getvalue()
+        # additive: scheme line present
+        self.assertIn("  scheme: v1", text)
+        # existing lines byte-identical
+        self.assertIn("Filter: secret", text)
+        self.assertIn("  enc.txt: Encrypted", text)
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_json_scheme_check_v1_is_warn_with_filter_key(self, mock_run):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        self.key_manager.get_scheme.return_value = "v1"
+        mock_run.side_effect = [MagicMock(stdout="x\n"), MagicMock(stdout="y\n")]
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch("os.path.exists", return_value=True), patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=True
+        ):
+            with contextlib.redirect_stdout(out):
+                rc = self.manager.doctor()
+        self.assertEqual(rc, 0)  # warn does NOT change exit code
+        payload = json.loads(out.getvalue())
+        scheme_checks = [c for c in payload["checks"] if c.get("check") == "scheme"]
+        self.assertEqual(len(scheme_checks), 1)
+        sc = scheme_checks[0]
+        self.assertEqual(sc["status"], "warn")
+        self.assertIn("filter", sc)
+        self.assertEqual(sc["filter"], "secret")
+        self.assertIn("v1", sc["detail"])
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_json_scheme_check_v2_is_ok(self, mock_run):
+        from git_secret_protector.core.output import Output
+
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        self.key_manager.get_scheme.return_value = "v2"
+        mock_run.side_effect = [MagicMock(stdout="x\n"), MagicMock(stdout="y\n")]
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with patch("os.path.exists", return_value=True), patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=True
+        ):
+            with contextlib.redirect_stdout(out):
+                rc = self.manager.doctor()
+        self.assertEqual(rc, 0)
+        payload = json.loads(out.getvalue())
+        scheme_checks = [c for c in payload["checks"] if c.get("check") == "scheme"]
+        self.assertEqual(len(scheme_checks), 1)
+        self.assertEqual(scheme_checks[0]["status"], "ok")
+
+    @patch("git_secret_protector.services.encryption_manager.subprocess.run")
+    def test_doctor_human_v1_scheme_prints_warn_and_exit_still_zero(self, mock_run):
+        self.git_attributes_parser.get_filter_names.return_value = ["secret"]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+        self.key_manager.is_cached.return_value = True
+        self.key_manager.resolve_parameter_name.return_value = "/path"
+        self.key_manager.get_scheme.return_value = "v1"
+        mock_run.side_effect = [MagicMock(stdout="x\n"), MagicMock(stdout="y\n")]
+        out = io.StringIO()
+        with patch("os.path.exists", return_value=True), patch.object(
+            self.manager, "_EncryptionManager__is_encrypted", return_value=True
+        ):
+            with contextlib.redirect_stdout(out):
+                rc = self.manager.doctor()
+        self.assertEqual(rc, 0)  # v1 warn must NOT fail doctor
+        self.assertIn("[WARN]", out.getvalue())
+        self.assertIn("v1", out.getvalue())
+
+    # ----- end Task-6 tests -----
+
 
 class TestMain(unittest.TestCase):
     @patch("git_secret_protector.main.EncryptionManager.show_project_version")

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -548,9 +548,47 @@ class TestEncryptionManagerService(unittest.TestCase):
                 "ok": True,
                 "command": "setup-aes-key",
                 "filter": "secret",
+                "scheme": "v2",
                 "message": "Successfully set up AES key for filter: secret",
             },
         )
+
+    def test_setup_aes_key_scheme_passed_to_key_manager(self):
+        self.manager.setup_aes_key("secret", scheme="v1")
+        self.key_manager.setup_aes_key_and_iv.assert_called_once_with(
+            "secret", scheme="v1"
+        )
+
+    def test_setup_aes_key_v1_emits_warning_to_stderr(self):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            self.manager.setup_aes_key("secret", scheme="v1")
+        err = stderr.getvalue()
+        self.assertIn("WARNING", err)
+        self.assertIn("v1", err)
+
+    def test_setup_aes_key_v2_does_not_emit_warning(self):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            self.manager.setup_aes_key("secret", scheme="v2")
+        self.assertNotIn("WARNING", stderr.getvalue())
+
+    def test_setup_aes_key_v1_json_envelope_includes_scheme(self):
+        from git_secret_protector.core.output import Output
+
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+        with contextlib.redirect_stdout(out):
+            self.manager.setup_aes_key("secret", scheme="v1")
+        payload = json.loads(out.getvalue())
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["scheme"], "v1")
+
+    def test_get_encryption_handler_uses_filter_scheme(self):
+        self.key_manager.retrieve_key_and_iv.return_value = (b"\x00" * 32, b"\x00" * 16)
+        self.key_manager.get_scheme.return_value = "v1"
+        handler = self.manager._EncryptionManager__get_encryption_handler("secret")
+        self.assertEqual(handler.scheme, "v1")
 
     def test_setup_aes_key_json_error_envelope_and_exit(self):
         from git_secret_protector.core.output import Output

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -1160,7 +1160,7 @@ class TestUpgradeScheme(unittest.TestCase):
 
     @patch("git_secret_protector.services.encryption_manager.AesEncryptionHandler")
     def test_verify_after_failure_exits_1(self, mock_handler_cls):
-        """If post-upgrade verify finds a file not v2, sys.exit(1)."""
+        """If post-upgrade verify finds a file not v2: sys.exit(1) AND set_scheme NOT called (blob stays v1)."""
         aes_key = b"\x00" * 32
         iv = b"\x01" * 16
         self.key_manager.get_scheme.return_value = "v1"
@@ -1190,6 +1190,8 @@ class TestUpgradeScheme(unittest.TestCase):
                     self.manager.upgrade_scheme("secret", assume_yes=True)
 
         self.assertEqual(ctx.exception.code, 1)
+        # Blob must stay v1 on verify failure - set_scheme must NOT have been called.
+        self.key_manager.set_scheme.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -898,5 +898,173 @@ class TestInitConfig(unittest.TestCase):
             self.assertIn("INVALID_BACKEND", stderr.getvalue())
 
 
+class TestUpgradeScheme(unittest.TestCase):
+    """Tests for EncryptionManager.upgrade_scheme."""
+
+    @patch("git_secret_protector.services.encryption_manager.get_settings")
+    def setUp(self, mock_get_settings):
+        mock_settings = MagicMock()
+        mock_settings.magic_header = generate_random_string()
+        mock_settings.storage_type.value = "AWS_SSM"
+        mock_settings.module_name = "git-secret-protector"
+        mock_settings.base_dir = "/repo/root"
+        mock_get_settings.return_value = mock_settings
+
+        self.git_attributes_parser = MagicMock(spec=GitAttributesParser)
+        self.key_manager = MagicMock()
+        self.key_rotator = MagicMock()
+        self.manager = EncryptionManager(
+            git_attributes_parser=self.git_attributes_parser,
+            key_manager=self.key_manager,
+            key_rotator=self.key_rotator,
+        )
+
+    def test_idempotent_already_v2(self):
+        """get_scheme -> 'v2': no-op, set_scheme NOT called, counts.reencrypted==0."""
+        from git_secret_protector.core.output import Output
+
+        self.key_manager.get_scheme.return_value = "v2"
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "a.txt",
+            "b.txt",
+        ]
+        out = io.StringIO()
+        self.manager.output = Output(json=True)
+
+        with contextlib.redirect_stdout(out):
+            self.manager.upgrade_scheme("secret")
+
+        self.key_manager.set_scheme.assert_not_called()
+        payload = json.loads(out.getvalue())
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["command"], "upgrade-scheme")
+        self.assertEqual(payload["counts"]["reencrypted"], 0)
+        self.assertEqual(payload["counts"]["total"], 2)
+
+    @patch("builtins.input", side_effect=EOFError)
+    def test_decline_on_eof_aborts_without_changes(self, mock_input):
+        """EOF on confirm prompt -> aborted, set_scheme NOT called."""
+        self.key_manager.get_scheme.return_value = "v1"
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "a.txt",
+            "b.txt",
+        ]
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            self.manager.upgrade_scheme("secret", assume_yes=False)
+
+        self.key_manager.set_scheme.assert_not_called()
+        self.assertIn("Aborted", stderr.getvalue())
+
+    def test_v1_to_v2_reencrypts_files_then_sets_scheme(self):
+        """v1 -> v2: re-encrypts each file with v2 handler, set_scheme called AFTER."""
+        aes_key = b"\x00" * 32
+        iv = b"\x01" * 16
+        self.key_manager.get_scheme.return_value = "v1"
+        self.key_manager.retrieve_key_and_iv.return_value = (aes_key, iv)
+        self.git_attributes_parser.get_files_for_filter.return_value = [
+            "a.txt",
+            "b.txt",
+        ]
+
+        call_order = []
+        magic_header = self.manager.magic_header
+        v2_byte = b"\x02"
+
+        mock_handler = MagicMock(spec=["decrypt_file", "encrypt_file"])
+        mock_handler.decrypt_file.side_effect = lambda f: call_order.append(
+            ("decrypt", f)
+        )
+        mock_handler.encrypt_file.side_effect = lambda f: call_order.append(
+            ("encrypt", f)
+        )
+        self.key_manager.set_scheme.side_effect = lambda f, s: call_order.append(
+            ("set_scheme", f, s)
+        )
+
+        def fake_open(path, mode="r", **kwargs):
+            if "b" in mode and "w" not in mode:
+                return io.BytesIO(magic_header + v2_byte + b"rest")
+            raise RuntimeError("unexpected open call in test")
+
+        from git_secret_protector.crypto.aes_encryption_handler import (
+            AesEncryptionHandler as RealHandler,
+        )
+
+        from git_secret_protector.core.output import Output
+
+        self.manager.output = Output(json=True)
+
+        with patch.object(
+            self.manager,
+            "_EncryptionManager__is_encrypted",
+            return_value=True,
+        ), patch("builtins.open", side_effect=fake_open), patch(
+            "git_secret_protector.services.encryption_manager.AesEncryptionHandler",
+            side_effect=lambda **kw: mock_handler,
+            **{"V2": RealHandler.V2},
+        ):
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.manager.upgrade_scheme("secret", assume_yes=True)
+
+        # decrypt + encrypt called for each file
+        self.assertEqual(
+            [(op, f) for op, f in [c[:2] for c in call_order if c[0] != "set_scheme"]],
+            [
+                ("decrypt", "a.txt"),
+                ("encrypt", "a.txt"),
+                ("decrypt", "b.txt"),
+                ("encrypt", "b.txt"),
+            ],
+        )
+        # set_scheme called after all re-encryptions
+        set_scheme_idx = next(
+            i for i, c in enumerate(call_order) if c[0] == "set_scheme"
+        )
+        last_encrypt_idx = max(i for i, c in enumerate(call_order) if c[0] == "encrypt")
+        self.assertGreater(set_scheme_idx, last_encrypt_idx)
+        self.key_manager.set_scheme.assert_called_once_with("secret", "v2")
+
+        payload = json.loads(out.getvalue())
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["counts"]["reencrypted"], 2)
+        self.assertEqual(payload["counts"]["total"], 2)
+
+    @patch("git_secret_protector.services.encryption_manager.AesEncryptionHandler")
+    def test_verify_after_failure_exits_1(self, mock_handler_cls):
+        """If post-upgrade verify finds a file not v2, sys.exit(1)."""
+        aes_key = b"\x00" * 32
+        iv = b"\x01" * 16
+        self.key_manager.get_scheme.return_value = "v1"
+        self.key_manager.retrieve_key_and_iv.return_value = (aes_key, iv)
+        self.git_attributes_parser.get_files_for_filter.return_value = ["a.txt"]
+
+        handler = MagicMock()
+        mock_handler_cls.return_value = handler
+
+        magic_header = self.manager.magic_header
+        # Version byte is v1 (not 0x02) - simulate failed upgrade
+        v1_content = magic_header + b"plain-base64-v1"
+
+        def fake_open(path, mode="r", **kwargs):
+            if "b" in mode and "w" not in mode:
+                return io.BytesIO(v1_content)
+            raise RuntimeError("unexpected open call in test")
+
+        with patch.object(
+            self.manager,
+            "_EncryptionManager__is_encrypted",
+            return_value=True,
+        ), patch("builtins.open", side_effect=fake_open):
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as ctx:
+                    self.manager.upgrade_scheme("secret", assume_yes=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_key_rotator.py
+++ b/tests/unit/test_key_rotator.py
@@ -1,0 +1,82 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from git_secret_protector.services.key_rotator import KeyRotator
+
+
+class TestKeyRotator(unittest.TestCase):
+    @patch("git_secret_protector.services.key_rotator.get_settings")
+    def setUp(self, mock_get_settings):
+        mock_settings = MagicMock()
+        mock_settings.magic_header = "ENCRYPTED"
+        mock_get_settings.return_value = mock_settings
+
+        self.aes_key_manager = MagicMock()
+        self.git_attributes_parser = MagicMock()
+        self.rotator = KeyRotator(
+            key_manager=self.aes_key_manager,
+            git_attributes_parser=self.git_attributes_parser,
+        )
+
+    @patch("git_secret_protector.services.key_rotator.AesEncryptionHandler")
+    def test_rotate_key_preserves_v1_scheme(self, mock_handler_cls):
+        """Rotating a v1 filter must NOT silently upgrade it to v2."""
+        current_key = b"current-key-bytes"
+        current_iv = b"current-iv-bytes"
+        new_key = b"new-key-bytes"
+        new_iv = b"new-iv-bytes"
+        files = ["secret.txt", "config.env"]
+
+        self.aes_key_manager.get_scheme.return_value = "v1"
+        self.aes_key_manager.retrieve_key_and_iv.side_effect = [
+            (current_key, current_iv),
+            (new_key, new_iv),
+        ]
+        self.git_attributes_parser.get_files_for_filter.return_value = files
+
+        self.rotator.rotate_key("my-filter")
+
+        # scheme read at the start
+        self.aes_key_manager.get_scheme.assert_called_once_with("my-filter")
+
+        # new key generated with preserved v1 scheme
+        self.aes_key_manager.setup_aes_key_and_iv.assert_called_once_with(
+            filter_name="my-filter", scheme="v1"
+        )
+
+        # two AesEncryptionHandler instantiations: decrypt then encrypt
+        self.assertEqual(mock_handler_cls.call_count, 2)
+        decrypt_call, encrypt_call = mock_handler_cls.call_args_list
+
+        # decrypt handler: no scheme override required (wire-byte-authoritative)
+        self.assertEqual(decrypt_call.kwargs.get("aes_key"), current_key)
+        self.assertEqual(decrypt_call.kwargs.get("iv"), current_iv)
+
+        # encrypt handler: must carry the preserved v1 scheme
+        self.assertEqual(encrypt_call.kwargs.get("aes_key"), new_key)
+        self.assertEqual(encrypt_call.kwargs.get("iv"), new_iv)
+        self.assertEqual(encrypt_call.kwargs.get("scheme"), "v1")
+
+    @patch("git_secret_protector.services.key_rotator.AesEncryptionHandler")
+    def test_rotate_key_preserves_v2_scheme(self, mock_handler_cls):
+        """Rotating a v2 filter threads v2 through to the new key setup and encrypt handler."""
+        current_key = b"current-key"
+        current_iv = b"current-iv"
+        new_key = b"new-key"
+        new_iv = b"new-iv"
+
+        self.aes_key_manager.get_scheme.return_value = "v2"
+        self.aes_key_manager.retrieve_key_and_iv.side_effect = [
+            (current_key, current_iv),
+            (new_key, new_iv),
+        ]
+        self.git_attributes_parser.get_files_for_filter.return_value = ["file.txt"]
+
+        self.rotator.rotate_key("v2-filter")
+
+        self.aes_key_manager.setup_aes_key_and_iv.assert_called_once_with(
+            filter_name="v2-filter", scheme="v2"
+        )
+
+        _, encrypt_call = mock_handler_cls.call_args_list
+        self.assertEqual(encrypt_call.kwargs.get("scheme"), "v2")

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -299,3 +299,28 @@ def test_encrypt_decrypt_stdout_is_pure_bytes_under_all_flags(tmp_path):
             f"stdout purity violated with flags={flags}: "
             f"got {dec.stdout[:60]!r}, expected {plaintext!r}"
         )
+
+
+def test_upgrade_scheme_subcommand_parses(tmp_path):
+    """upgrade-scheme --help must be accepted by argparse (parses without error)."""
+    result = _run_main(["upgrade-scheme", "--help"], tmp_path)
+    assert result.returncode == 0
+    assert "upgrade-scheme" in result.stdout or "upgrade" in result.stdout
+
+
+def test_upgrade_scheme_filter_name_and_yes_parse(tmp_path):
+    """upgrade-scheme myfilter -y must not produce an argparse error (exit 2)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=myfilter\n")
+    _seed_key_cache(repo, "myfilter")
+
+    result = _run_main(
+        ["--repo-root", str(repo), "upgrade-scheme", "myfilter", "-y"],
+        tmp_path,
+    )
+    # returncode 2 = argparse error; anything else means argparse accepted it
+    assert (
+        result.returncode != 2
+    ), f"argparse rejected upgrade-scheme -y: {result.stderr}"

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -224,6 +224,44 @@ def test_init_creates_config_in_fresh_git_repo(tmp_path):
     assert cfg["DEFAULT"]["module_name"] == "demo"
 
 
+def test_setup_aes_key_scheme_v1_parses(tmp_path):
+    """setup-aes-key --scheme v1 must be accepted by argparse."""
+    import argparse
+    import sys as _sys
+
+    # Import main module to get its parser
+    ROOT_SRC = ROOT / "src"
+    _sys.path.insert(0, str(ROOT_SRC))
+    from git_secret_protector import main as _main
+
+    # Rebuild the parser by running main() up to parse_args - instead, replicate
+    # the argparse setup just enough to test the --scheme flag.
+    result = _run_main(["setup-aes-key", "--help"], tmp_path)
+    assert "--scheme" in result.stdout
+    assert "v1" in result.stdout
+    assert "v2" in result.stdout
+
+
+def test_setup_aes_key_scheme_v1_reaches_manager(tmp_path):
+    """Subprocess: setup-aes-key myfilter --scheme v1 must not crash on argparse."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / ".gitattributes").write_text("*.secret filter=myfilter\n")
+    _seed_key_cache(repo, "myfilter")
+
+    from unittest.mock import patch, MagicMock
+
+    # Just verify argparse passes without error (backend call will fail w/o creds,
+    # that's fine - we only need returncode != 2, which would mean argparse error)
+    result = _run_main(
+        ["--repo-root", str(repo), "setup-aes-key", "myfilter", "--scheme", "v1"],
+        tmp_path,
+    )
+    # returncode 2 = argparse error; anything else means argparse accepted it
+    assert result.returncode != 2, f"argparse rejected --scheme v1: {result.stderr}"
+
+
 def test_encrypt_decrypt_stdout_is_pure_bytes_under_all_flags(tmp_path):
     """encrypt/decrypt stdout must equal exact payload bytes for every flag combo."""
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary

### Why
v1.2.x clients only understand the legacy unauthenticated AES-CBC scheme; v1.4.0+ clients use authenticated AES-256-CTR + HMAC ("v2"). A repo with both could not interoperate: a v2-encrypted file is unreadable by an old client. This makes the encryption scheme a property of the stored key blob so both coexist.

### What
- `setup-aes-key <filter> --scheme {v1,v2}` (default **v2**). `--scheme v1` opts a filter down to the legacy scheme for repos that still have un-upgradeable pre-1.4.0 clients.
- `upgrade-scheme <filter>` (`-y/--yes`): one-way v1 -> v2 migration that re-encrypts all of a filter's files. Confirm-gated, idempotent (no-op if already v2), verify-after, no downgrade.
- `rotate-key` now preserves the filter's scheme (a v1 filter stays v1 after rotation).
- `status` / `doctor` surface the active scheme per filter; `doctor` flags v1 as `[WARN]`.

### Solution
The key blob's `version` field (1/2) is the authoritative **encrypt** scheme selector; the handler reads it per filter. **Decrypt stays version-byte-authoritative** and independent of the blob, so a v2 key still decrypts on-disk v1 files mid-migration. `upgrade-scheme` re-encrypts, verifies every file is v2, then flips the blob last - a failed/interrupted upgrade leaves an honest v1 blob and on-disk files that remain decryptable, and a re-run cleanly retries.

> SECURITY: `--scheme v1` deliberately reintroduces **unauthenticated** AES-CBC for backward compatibility only. It is warned at setup, flagged `[WARN]` in `doctor`/`status`, and should be migrated away with `upgrade-scheme` as soon as all clients are >= 1.4.0.

This change is **additive** - v2 remains the default and existing v2 users see no behavior change.

## Types of Changes
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- `poetry run pytest tests/unit/` - 138 passed.
- Covers: v1 encrypt round-trip + determinism + no version byte; decrypt dispatch by wire byte independent of blob scheme; setup --scheme v1 warning + JSON scheme field; rotate preserves scheme; upgrade-scheme idempotent/confirm/EOF-decline/verify-fail-exit/ordering; status+doctor scheme surfacing with v1 = warn (exit code unaffected). The encrypt/decrypt filter stdout-purity guard-rail still holds.
