### PR TITLE
fix: cache-only git filters + fast backend timeouts to prevent required-filter hang

### DIFF
--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -90,7 +90,7 @@ class AesKeyManager:
     :raises AesKeyError: If there is any error during the deletion process
     """
 
-    def retrieve_key_and_iv(self, filter_name):
+    def retrieve_key_and_iv(self, filter_name, cache_only: bool = False):
         logger.info("Retrieve AES key and IV for filter: %s", filter_name)
 
         try:
@@ -103,11 +103,20 @@ class AesKeyManager:
                     local_data["iv"]
                 )
 
+            # Required git filters must stay cache-only so they never hang on network.
+            if cache_only:
+                raise AesKeyError(
+                    f"AES key for filter '{filter_name}' is not cached locally. "
+                    f"Run: git-secret-protector pull-aes-key {filter_name}"
+                )
+
             parameter_name = self._parameter_name(filter_name=filter_name)
             data = json.loads(self._get_storage_manager().retrieve(name=parameter_name))
             self.cache_key_iv_locally(filter_name, json.dumps(data))
 
             return base64.b64decode(data["aes_key"]), base64.b64decode(data["iv"])
+        except AesKeyError:
+            raise
         except Exception as e:
             raise AesKeyError(
                 f"Failed to retrieve AES key and IV for filter '{filter_name}': {str(e)}"

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -282,6 +282,10 @@ class EncryptionManager:
             )
         except Exception as e:
             logging.error(f"Encrypt data command failed: {e}", exc_info=True)
+            # stderr is safe for git filters (stdout carries the binary payload) and,
+            # unlike the file logger, is shown by git - so the cache-miss
+            # 'run pull-aes-key' hint actually reaches the user.
+            print(f"git-secret-protector: {e}", file=sys.stderr)
             sys.exit(1)
 
     def decrypt_stdin(self, file_name):
@@ -312,6 +316,9 @@ class EncryptionManager:
             )
         except Exception as e:
             logging.error(f"Decrypt data command failed: {e}", exc_info=True)
+            # Surface on stderr (git shows it) so a cache-miss key error is diagnosable;
+            # still pass the ciphertext through on stdout so checkout degrades, not hangs.
+            print(f"git-secret-protector: {e}", file=sys.stderr)
             sys.stdout.buffer.write(encrypted_data)
             sys.stdout.buffer.flush()
 

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -272,7 +272,7 @@ class EncryptionManager:
                 sys.exit(1)
 
             encrypted_data = self.__get_encryption_handler(
-                filter_name=filter_name
+                filter_name=filter_name, cache_only=True
             ).encrypt_data(input_data)
 
             sys.stdout.buffer.write(encrypted_data)
@@ -301,7 +301,7 @@ class EncryptionManager:
                 return
 
             decrypted_data = self.__get_encryption_handler(
-                filter_name=filter_name
+                filter_name=filter_name, cache_only=True
             ).decrypt_data(encrypted_data)
             logger.debug("Decrypted file: %s", file_name)
 
@@ -899,8 +899,10 @@ class EncryptionManager:
             filter_name,
         )
 
-    def __get_encryption_handler(self, filter_name: str):
-        aes_key, iv = self.key_manager.retrieve_key_and_iv(filter_name)
+    def __get_encryption_handler(self, filter_name: str, cache_only: bool = False):
+        aes_key, iv = self.key_manager.retrieve_key_and_iv(
+            filter_name, cache_only=cache_only
+        )
         scheme = self.key_manager.get_scheme(filter_name)
         return AesEncryptionHandler(
             aes_key=aes_key, iv=iv, magic_header=self.magic_header, scheme=scheme

--- a/src/git_secret_protector/storage/aws_ssm_storage_manager.py
+++ b/src/git_secret_protector/storage/aws_ssm_storage_manager.py
@@ -17,6 +17,13 @@ def _boto3():
     return boto3
 
 
+# Fail fast when AWS is unreachable so a required git filter never hangs for minutes.
+def _boto_config():
+    from botocore.config import Config
+
+    return Config(connect_timeout=2, read_timeout=5, retries={"max_attempts": 1})
+
+
 def _get_short_region(region):
     region_parts = region.split("-")
     return f"{region_parts[0][:2]}{region_parts[1][:2]}{region_parts[2]}"
@@ -32,7 +39,7 @@ class AwsSsmStorageManager(StorageManagerInterface):
     def account_id(self):
         if self._account_id is None:
             try:
-                sts_client = _boto3().client("sts")
+                sts_client = _boto3().client("sts", config=_boto_config())
                 self._account_id = sts_client.get_caller_identity().get("Account")
             except NoCredentialsError:
                 raise StorageError(
@@ -56,7 +63,7 @@ class AwsSsmStorageManager(StorageManagerInterface):
     def client(self):
         if self._client is None:
             try:
-                self._client = _boto3().client("ssm")
+                self._client = _boto3().client("ssm", config=_boto_config())
             except NoRegionError:
                 raise StorageError(
                     "No AWS region configured. Please ensure your terminal is logged in to AWS."

--- a/src/git_secret_protector/storage/gcp_secret_storage_manager.py
+++ b/src/git_secret_protector/storage/gcp_secret_storage_manager.py
@@ -9,6 +9,7 @@ from git_secret_protector.storage.storage_manager_interface import (
 )
 
 logger = logging.getLogger(__name__)
+GCP_RPC_TIMEOUT_SECONDS = 5.0
 
 
 def _secretmanager():
@@ -96,7 +97,10 @@ class GcpSecretStorageManager(StorageManagerInterface):
             logger.info(
                 "Retrieving secret from GCP Secret Manager with ID: %s", secret_id
             )
-            response = self.client.access_secret_version(name=secret_id)
+            # Fail fast so a required git filter never hangs on backend RPCs.
+            response = self.client.access_secret_version(
+                name=secret_id, timeout=GCP_RPC_TIMEOUT_SECONDS
+            )
             return response.payload.data.decode("UTF-8")
         except NotFound:
             raise ValueError(f"Secret [name={name}] not found.")

--- a/src/git_secret_protector/storage/gcp_secret_storage_manager.py
+++ b/src/git_secret_protector/storage/gcp_secret_storage_manager.py
@@ -64,7 +64,10 @@ class GcpSecretStorageManager(StorageManagerInterface):
         AlreadyExists, GoogleAPIError, NotFound = _google_exceptions()
         try:
             # Check if the secret already exists, otherwise create it
-            self.client.access_secret_version(name=f"{secret_id}/versions/latest")
+            self.client.access_secret_version(
+                name=f"{secret_id}/versions/latest",
+                timeout=GCP_RPC_TIMEOUT_SECONDS,
+            )
         except NotFound:
             # Create the secret if it doesn't exist
             try:
@@ -73,6 +76,7 @@ class GcpSecretStorageManager(StorageManagerInterface):
                     parent=f"projects/{self.project_id}",
                     secret_id=name,
                     secret=Secret(replication={"automatic": {}}),
+                    timeout=GCP_RPC_TIMEOUT_SECONDS,
                 )
             except AlreadyExists:
                 raise ValueError(f"Secret with name [{name}] already exists.")
@@ -85,7 +89,9 @@ class GcpSecretStorageManager(StorageManagerInterface):
         try:
             _, SecretPayload = _secret_types()
             self.client.add_secret_version(
-                parent=secret_id, payload=SecretPayload({"data": value.encode("UTF-8")})
+                parent=secret_id,
+                payload=SecretPayload({"data": value.encode("UTF-8")}),
+                timeout=GCP_RPC_TIMEOUT_SECONDS,
             )
         except GoogleAPIError as e:
             raise StorageError(f"Failed to add secret version: {str(e)}") from e
@@ -113,7 +119,7 @@ class GcpSecretStorageManager(StorageManagerInterface):
         secret_id = f"projects/{self.project_id}/secrets/{name}"
         _, GoogleAPIError, NotFound = _google_exceptions()
         try:
-            self.client.delete_secret(name=secret_id)
+            self.client.delete_secret(name=secret_id, timeout=GCP_RPC_TIMEOUT_SECONDS)
         except NotFound:
             raise ValueError(f"Secret [name={name}] not found.")
         except GoogleAPIError as e:
@@ -125,7 +131,10 @@ class GcpSecretStorageManager(StorageManagerInterface):
         secret_id = f"projects/{self.project_id}/secrets/{name}"
         _, GoogleAPIError, NotFound = _google_exceptions()
         try:
-            self.client.access_secret_version(name=f"{secret_id}/versions/latest")
+            self.client.access_secret_version(
+                name=f"{secret_id}/versions/latest",
+                timeout=GCP_RPC_TIMEOUT_SECONDS,
+            )
             return True
         except NotFound:
             return False

--- a/tests/unit/test_aes_key_manager.py
+++ b/tests/unit/test_aes_key_manager.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 
 from git_secret_protector.core.settings import StorageType
 from git_secret_protector.crypto.aes_key_manager import AesKeyManager
+from git_secret_protector.error.aes_key_error import AesKeyError
 
 
 class TestAesKeyManager(unittest.TestCase):
@@ -96,6 +97,34 @@ class TestAesKeyManager(unittest.TestCase):
         self.assertEqual(oct(os.stat(cache_path).st_mode & 0o777), "0o600")
 
         data = json.loads(json_data)
+        self.assertEqual(aes_key, base64.b64decode(data["aes_key"]))
+        self.assertEqual(iv, base64.b64decode(data["iv"]))
+
+    @patch("os.path.exists", return_value=False)
+    def test_retrieve_key_and_iv_cache_only_miss_raises_with_pull_hint(self, _):
+        filter_name = secrets.token_hex(8)
+        self.aes_key_manager.storage_manager = self.mock_storage_manager
+
+        with self.assertRaises(AesKeyError) as context:
+            self.aes_key_manager.retrieve_key_and_iv(filter_name, cache_only=True)
+
+        self.mock_storage_manager.retrieve.assert_not_called()
+        self.assertIn("pull-aes-key", str(context.exception))
+
+    @patch("os.path.exists", return_value=True)
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    def test_retrieve_key_and_iv_cache_only_hit_uses_cache(self, mock_open, _):
+        json_data = self.random_encoded_data()
+        filter_name = secrets.token_hex(8)
+        self.aes_key_manager.storage_manager = self.mock_storage_manager
+        mock_open.return_value.read.return_value = json_data
+
+        aes_key, iv = self.aes_key_manager.retrieve_key_and_iv(
+            filter_name, cache_only=True
+        )
+
+        data = json.loads(json_data)
+        self.mock_storage_manager.retrieve.assert_not_called()
         self.assertEqual(aes_key, base64.b64decode(data["aes_key"]))
         self.assertEqual(iv, base64.b64decode(data["iv"]))
 

--- a/tests/unit/test_aws_ssm_storage_manager.py
+++ b/tests/unit/test_aws_ssm_storage_manager.py
@@ -3,7 +3,10 @@ import unittest
 from unittest.mock import MagicMock
 
 from git_secret_protector.error.storage_error import StorageError
-from git_secret_protector.storage.aws_ssm_storage_manager import AwsSsmStorageManager
+from git_secret_protector.storage.aws_ssm_storage_manager import (
+    AwsSsmStorageManager,
+    _boto_config,
+)
 
 
 class TestAwsSsmStorageManager(unittest.TestCase):
@@ -47,6 +50,13 @@ class TestAwsSsmStorageManager(unittest.TestCase):
         result = self.manager.retrieve("/path/to/secret")
 
         self.assertEqual(result, value)
+
+    def test_boto_config_uses_fail_fast_timeouts(self):
+        config = _boto_config()
+
+        self.assertEqual(config.connect_timeout, 2)
+        self.assertEqual(config.read_timeout, 5)
+        self.assertEqual(config.retries["max_attempts"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -200,11 +200,12 @@ class TestEncryptionManagerService(unittest.TestCase):
             self.manager,
             "_EncryptionManager__get_encryption_handler",
             return_value=handler,
-        ):
+        ) as mock_get_handler:
             with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
                 self.manager.encrypt_stdin("secrets.env")
 
         self.assertEqual(stdout_buffer.getvalue(), b"ciphertext")
+        mock_get_handler.assert_called_once_with(filter_name="secret", cache_only=True)
 
     def test_pull_aes_key_exits_non_zero_when_retrieve_raises(self):
         self.key_manager.retrieve_key_and_iv.side_effect = RuntimeError("boom")
@@ -490,6 +491,40 @@ class TestEncryptionManagerService(unittest.TestCase):
             with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
                 self.manager.decrypt_stdin("secrets.env")
 
+        self.assertEqual(stdout_buffer.getvalue(), encrypted_data)
+
+    def test_encrypt_stdin_cache_miss_uses_cache_only_lookup(self):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+        stdout_buffer = io.BytesIO()
+        stdin = SimpleNamespace(buffer=io.BytesIO(b"plain-secret"))
+        stdout = SimpleNamespace(buffer=stdout_buffer)
+        self.key_manager.retrieve_key_and_iv.side_effect = RuntimeError("cache miss")
+
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            with self.assertRaises(SystemExit):
+                self.manager.encrypt_stdin("secrets.env")
+
+        self.key_manager.retrieve_key_and_iv.assert_called_once_with(
+            "secret", cache_only=True
+        )
+        self.key_manager.get_scheme.assert_not_called()
+        self.assertEqual(stdout_buffer.getvalue(), b"")
+
+    def test_decrypt_stdin_cache_miss_uses_cache_only_lookup(self):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+        encrypted_data = b"ciphertext"
+        stdout_buffer = io.BytesIO()
+        stdin = SimpleNamespace(buffer=io.BytesIO(encrypted_data))
+        stdout = SimpleNamespace(buffer=stdout_buffer)
+        self.key_manager.retrieve_key_and_iv.side_effect = RuntimeError("cache miss")
+
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            self.manager.decrypt_stdin("secrets.env")
+
+        self.key_manager.retrieve_key_and_iv.assert_called_once_with(
+            "secret", cache_only=True
+        )
+        self.key_manager.get_scheme.assert_not_called()
         self.assertEqual(stdout_buffer.getvalue(), encrypted_data)
 
     @patch("git_secret_protector.services.encryption_manager.subprocess.run")

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -527,6 +527,41 @@ class TestEncryptionManagerService(unittest.TestCase):
         self.key_manager.get_scheme.assert_not_called()
         self.assertEqual(stdout_buffer.getvalue(), encrypted_data)
 
+    def test_encrypt_stdin_cache_miss_prints_hint_to_stderr(self):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+        stdin = SimpleNamespace(buffer=io.BytesIO(b"plain-secret"))
+        stdout = SimpleNamespace(buffer=io.BytesIO())
+        stderr = io.StringIO()
+        self.key_manager.retrieve_key_and_iv.side_effect = RuntimeError(
+            "AES key for filter 'secret' is not cached locally. "
+            "Run: git-secret-protector pull-aes-key secret"
+        )
+
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout), patch(
+            "sys.stderr", stderr
+        ):
+            with self.assertRaises(SystemExit):
+                self.manager.encrypt_stdin("secrets.env")
+
+        self.assertIn("pull-aes-key", stderr.getvalue())
+
+    def test_decrypt_stdin_cache_miss_prints_hint_to_stderr(self):
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+        stdin = SimpleNamespace(buffer=io.BytesIO(b"ciphertext"))
+        stdout = SimpleNamespace(buffer=io.BytesIO())
+        stderr = io.StringIO()
+        self.key_manager.retrieve_key_and_iv.side_effect = RuntimeError(
+            "AES key for filter 'secret' is not cached locally. "
+            "Run: git-secret-protector pull-aes-key secret"
+        )
+
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout), patch(
+            "sys.stderr", stderr
+        ):
+            self.manager.decrypt_stdin("secrets.env")
+
+        self.assertIn("pull-aes-key", stderr.getvalue())
+
     @patch("git_secret_protector.services.encryption_manager.subprocess.run")
     def test_setup_filters_sets_required_for_existing_filter(self, mock_run):
         self.git_attributes_parser.get_filter_names.return_value = ["secret"]


### PR DESCRIPTION
## Summary

### Why
Filters are wired as per-file `clean`/`smudge` with `required=true`. On a local key-cache **miss**, the smudge path made a blocking STS+SSM (or GCP) call, so when the backend was unreachable git hung for minutes until interrupted - repeatedly hit when opening a terminal/editor into a repo wired with the filters.

### What
The per-file git-filter paths are now cache-only and never touch the network; explicit network commands fail fast instead of hanging.

### Solution
```mermaid
flowchart TD
    A["git checkout / add -> clean/smudge per file"] --> B{key in local cache?}
    B -- yes --> C[decrypt / encrypt]
    B -- "no (cache_only=True)" --> D["raise immediately:<br/>run pull-aes-key &lt;filter&gt;<br/>(no boto3, no socket)"]
    E["explicit: pull-aes-key / rotate / bulk"] --> F{key in cache?}
    F -- no --> G["backend fetch<br/>AWS connect=2s read=5s max_attempts=1<br/>GCP rpc timeout=5s"]
```

- `retrieve_key_and_iv(..., cache_only=False)`; the stdin clean/smudge paths pass `cache_only=True`, so a miss raises with an actionable `pull-aes-key` hint and never constructs the storage client.
- AWS sts/ssm clients build with a short botocore `Config`; GCP retrieve RPC gets a 5s timeout - explicit network paths fail in seconds, not minutes.
- Bulk/pull/rotate/upgrade keep network access (default `cache_only=False`).
- No change to CLI surface, wire format, key derivation, or scheme versioning.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
`poetry run pytest tests/unit/` - 143 passed. Added regressions: cache-only miss raises + asserts the storage backend is never called (`retrieve.assert_not_called()`) and preserves the `pull-aes-key` hint; cache-only hit returns from cache without a backend call; default path still fetches; AWS clients build with the fail-fast timeout config.
