### PR TITLE
feat: fail-closed decrypt filter on unsupported format + doctor supported schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ must touch this file (changelog-touched.yml); `[skip changelog]` in the PR body
 opts out.
 -->
 
+## [Unreleased]
+
+- The git decrypt filter now **fails closed** on a blob or key whose format is newer than this client supports (typed `UnsupportedFormatError`): it exits non-zero instead of silently writing the ciphertext into the working tree. Transient cache-miss errors still degrade (pass through) as before.
+- `doctor` now reports the schemes this client supports (`this client supports schemes: v1, v2 (new-key default: ...)`), so team version skew is diagnosable before it breaks a checkout.
+
 ## [1.7.1] - 2026-07-27
 
 - Migrate the release flow to CHANGELOG-driven (`release.yml` + `changelog-touched.yml`), replacing release-please.

--- a/src/git_secret_protector/crypto/aes_encryption_handler.py
+++ b/src/git_secret_protector/crypto/aes_encryption_handler.py
@@ -8,7 +8,13 @@ from Crypto.Protocol.KDF import HKDF
 from Crypto.Util import Counter
 from Crypto.Util.Padding import pad, unpad
 
+from git_secret_protector.error.unsupported_format_error import UnsupportedFormatError
+
 logger = logging.getLogger(__name__)
+
+# Wire/key schemes this client can produce and read. Surfaced by `doctor` so
+# version skew across a team is diagnosable before it breaks a checkout.
+SUPPORTED_SCHEMES = ("v1", "v2")
 
 
 class AesEncryptionHandler:
@@ -111,7 +117,7 @@ class AesEncryptionHandler:
         if not version_byte or version_byte[0] in self._B64_FIRST_BYTES:
             return self._decrypt_v1(encrypted_data)
 
-        raise ValueError(
+        raise UnsupportedFormatError(
             "Cannot decrypt: unrecognized wire format (possibly encrypted by a newer "
             "git-secret-protector client); upgrade git-secret-protector."
         )

--- a/src/git_secret_protector/crypto/aes_key_manager.py
+++ b/src/git_secret_protector/crypto/aes_key_manager.py
@@ -5,6 +5,7 @@ import os
 
 from git_secret_protector.core.settings import get_settings
 from git_secret_protector.error.aes_key_error import AesKeyError
+from git_secret_protector.error.unsupported_format_error import UnsupportedFormatError
 from git_secret_protector.storage.storage_manager_factory import StorageManagerFactory
 
 logger = logging.getLogger(__name__)
@@ -196,10 +197,12 @@ class AesKeyManager:
                 return "v1"
             if version == 2:
                 return "v2"
-            raise AesKeyError(
+            raise UnsupportedFormatError(
                 f"Key blob for filter '{filter_name}' has version {version}, newer "
                 f"than this client supports; upgrade git-secret-protector."
             )
+        except UnsupportedFormatError:
+            raise
         except AesKeyError:
             raise
         except Exception as e:

--- a/src/git_secret_protector/error/unsupported_format_error.py
+++ b/src/git_secret_protector/error/unsupported_format_error.py
@@ -1,0 +1,12 @@
+class UnsupportedFormatError(ValueError):
+    """Raised when a blob or key uses a wire/scheme version this client does not
+    understand (newer than supported), as opposed to a transient failure like a
+    cache miss. The git filter treats this as fail-closed: abort rather than pass
+    ciphertext through as if it were content.
+
+    Subclasses ValueError so existing `except ValueError` decrypt paths keep working.
+    """
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)

--- a/src/git_secret_protector/services/encryption_manager.py
+++ b/src/git_secret_protector/services/encryption_manager.py
@@ -11,8 +11,12 @@ import injector
 from git_secret_protector.core.git_attributes_parser import GitAttributesParser
 from git_secret_protector.core.output import Output
 from git_secret_protector.core.settings import StorageType, get_settings
-from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
+from git_secret_protector.crypto.aes_encryption_handler import (
+    AesEncryptionHandler,
+    SUPPORTED_SCHEMES,
+)
 from git_secret_protector.crypto.aes_key_manager import AesKeyManager
+from git_secret_protector.error.unsupported_format_error import UnsupportedFormatError
 from git_secret_protector.services.key_rotator import KeyRotator
 from git_secret_protector.utils.project_version import get_project_version_from_metadata
 
@@ -318,6 +322,13 @@ class EncryptionManager:
             logging.info(
                 f"Successfully decrypted data from stdin for file: {file_name}"
             )
+        except UnsupportedFormatError as e:
+            # Newer/unknown wire or key format: fail closed. Do NOT pass the ciphertext
+            # through as if it were content (that would silently land encrypted bytes in
+            # the working tree) - abort the checkout so the skew is visible.
+            logging.error(f"Decrypt data command failed: {e}", exc_info=True)
+            print(f"git-secret-protector: {e}", file=sys.stderr)
+            sys.exit(1)
         except Exception as e:
             logging.error(f"Decrypt data command failed: {e}", exc_info=True)
             # Surface on stderr (git shows it) so a cache-miss key error is diagnosable;
@@ -544,6 +555,19 @@ class EncryptionManager:
         )
         checks.append(
             {"check": "repository_context", "status": "ok", "detail": repo_lines}
+        )
+
+        # Surface which schemes this client can read/produce so version skew across a
+        # team is diagnosable here, before a mismatched blob breaks someone's checkout.
+        checks.append(
+            {
+                "check": "supported_schemes",
+                "status": "ok",
+                "detail": (
+                    f"this client supports schemes: {', '.join(SUPPORTED_SCHEMES)} "
+                    f"(new-key default: {settings.encryption_scheme})"
+                ),
+            }
         )
 
         if os.path.exists(settings.config_file):

--- a/tests/unit/test_aes_encryption_handler.py
+++ b/tests/unit/test_aes_encryption_handler.py
@@ -6,6 +6,7 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 
 from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
+from git_secret_protector.error.unsupported_format_error import UnsupportedFormatError
 
 
 class TestAesEncryptionHandler(unittest.TestCase):
@@ -181,7 +182,9 @@ class TestAesEncryptionHandlerDispatchHardening(unittest.TestCase):
         # 0x03 (and any control byte < 0x2B that is not 0x02) means "newer client".
         blob = self.magic_header + b"\x03" + base64.b64encode(b"whatever-payload")
 
-        with self.assertRaisesRegex(ValueError, "newer git-secret-protector client"):
+        with self.assertRaisesRegex(
+            UnsupportedFormatError, "newer git-secret-protector client"
+        ):
             self.handler.decrypt_data(blob)
 
     def test_stripped_v2_version_byte_does_not_silently_cbc(self):
@@ -217,7 +220,9 @@ class TestAesEncryptionHandlerDispatchHardening(unittest.TestCase):
         v2 = self.handler.encrypt_data(b"secret")
         tampered = self.magic_header + b"\x04" + v2[len(self.magic_header) + 1 :]
 
-        with self.assertRaisesRegex(ValueError, "newer git-secret-protector client"):
+        with self.assertRaisesRegex(
+            UnsupportedFormatError, "newer git-secret-protector client"
+        ):
             self.handler.decrypt_data(tampered)
 
     def test_plaintext_beginning_with_magic_header_is_skipped(self):

--- a/tests/unit/test_aes_key_manager.py
+++ b/tests/unit/test_aes_key_manager.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ClientError
 from git_secret_protector.core.settings import StorageType
 from git_secret_protector.crypto.aes_key_manager import AesKeyManager
 from git_secret_protector.error.aes_key_error import AesKeyError
+from git_secret_protector.error.unsupported_format_error import UnsupportedFormatError
 
 
 class TestAesKeyManager(unittest.TestCase):
@@ -291,7 +292,9 @@ class TestAesKeyManagerScheme(unittest.TestCase):
         blob = self._make_blob(version=4)  # newer than this client supports
         self.aes_key_manager.cache_key_iv_locally(filter_name, json.dumps(blob))
 
-        with self.assertRaisesRegex(AesKeyError, "newer than this client supports"):
+        with self.assertRaisesRegex(
+            UnsupportedFormatError, "newer than this client supports"
+        ):
             self.aes_key_manager.get_scheme(filter_name)
 
     def test_get_scheme_cache_miss_falls_back_to_backend(self):

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -17,6 +17,7 @@ from git_secret_protector.core.git_attributes_parser import GitAttributesParser
 from git_secret_protector.crypto.aes_encryption_handler import AesEncryptionHandler
 from git_secret_protector.crypto.aes_key_manager import AesKeyManager
 from git_secret_protector.main import show_project_version
+from git_secret_protector.error.unsupported_format_error import UnsupportedFormatError
 from git_secret_protector.services.encryption_manager import EncryptionManager
 from tests.utils.random_utils import generate_random_string
 
@@ -512,6 +513,27 @@ class TestEncryptionManagerService(unittest.TestCase):
 
         self.assertEqual(stdout_buffer.getvalue(), encrypted_data)
 
+    def test_decrypt_stdin_exits_and_writes_nothing_on_unsupported_format(self):
+        # An unknown/newer wire or key format must fail closed: exit non-zero and NOT
+        # pass the ciphertext through as if it were the file's content.
+        self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
+        encrypted_data = b"\x03unknown-format"
+        stdout_buffer = io.BytesIO()
+        stdin = SimpleNamespace(buffer=io.BytesIO(encrypted_data))
+        stdout = SimpleNamespace(buffer=stdout_buffer)
+
+        with patch.object(
+            self.manager,
+            "_EncryptionManager__get_encryption_handler",
+            side_effect=UnsupportedFormatError("encrypted by a newer client"),
+        ):
+            with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+                with self.assertRaises(SystemExit) as ctx:
+                    self.manager.decrypt_stdin("secrets.env")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(stdout_buffer.getvalue(), b"")  # no ciphertext-through
+
     def test_encrypt_stdin_cache_miss_uses_cache_only_lookup(self):
         self.git_attributes_parser.get_filter_name_for_file.return_value = "secret"
         stdout_buffer = io.BytesIO()
@@ -796,6 +818,10 @@ class TestEncryptionManagerService(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["exit_code"], 1)
         self.assertTrue(any(c["status"] == "fail" for c in payload["checks"]))
+        supported = next(
+            c for c in payload["checks"] if c["check"] == "supported_schemes"
+        )
+        self.assertIn("v1, v2", supported["detail"])
 
     @patch("git_secret_protector.services.encryption_manager.subprocess.run")
     def test_doctor_json_per_filter_checks_distinguishable_with_two_filters(


### PR DESCRIPTION
Closes the principal-SRE follow-up from #98 (tkt #2846).

## Why
`decrypt_stdin` caught **all** exceptions and wrote the raw ciphertext into the working tree ("degrade, not hang"). That silently swallowed the fail-closed raises: a blob from a **newer** client landed as ciphertext-in-file at the git smudge-filter boundary instead of a hard abort - the dominant usage path, so the security intent was muted where it mattered most.

## What
- New typed **`UnsupportedFormatError`** (subclass of `ValueError`) raised by the handler for an unknown wire version and by `get_scheme` for a key-blob version `>= 3`.
- `decrypt_stdin` catches it and **`sys.exit(1)`** - does NOT pass ciphertext through as content. Transient cache-miss (`AesKeyError`/other) still degrades exactly as before. `encrypt_stdin` already fails closed.
- `doctor` adds a `supported_schemes` check: `this client supports schemes: v1, v2 (new-key default: ...)` - so team version skew is diagnosable before it breaks a checkout.

## Test plan
- `poetry run pytest tests/unit/` - 163 passed. New: `decrypt_stdin` unsupported-format -> exit(1) + no ciphertext-through; existing degrade tests (RuntimeError, cache-miss) still assert pass-through; `get_scheme` v>=3 -> `UnsupportedFormatError`; handler unknown-byte -> `UnsupportedFormatError`; doctor JSON includes `supported_schemes`.

Change is under `## [Unreleased]`, so merging does not auto-release.