### PR TITLE
release: 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ must touch this file (changelog-touched.yml); `[skip changelog]` in the PR body
 opts out.
 -->
 
-## [Unreleased]
-
+## [1.8.0] - 2026-07-28
 - The git decrypt filter now **fails closed** on a blob or key whose format is newer than this client supports (typed `UnsupportedFormatError`): it exits non-zero instead of silently writing the ciphertext into the working tree. Transient cache-miss errors still degrade (pass through) as before.
 - `doctor` now reports the schemes this client supports (`this client supports schemes: v1, v2 (new-key default: ...)`), so team version skew is diagnosable before it breaks a checkout.
 


### PR DESCRIPTION
Cuts **v1.8.0** via the CHANGELOG-driven flow (renames `## [Unreleased]` -> `## [1.8.0]`). On merge, release.yml bumps pyproject, tags v1.8.0 + GitHub Release, and publishes to PyPI.

Ships since 1.7.1:
- Fail-closed decrypt filter on unsupported wire/key format (typed `UnsupportedFormatError` -> exit non-zero, no ciphertext-through); cache-miss still degrades.
- `doctor` reports supported schemes for version-skew diagnosis.

Docs-only changelog rename (release trigger); PR-Agent bypassed.