### PR TITLE
ci: exempt dependabot PRs from the changelog-touched gate

### DIFF
--- a/.github/workflows/changelog-touched.yml
+++ b/.github/workflows/changelog-touched.yml
@@ -22,8 +22,14 @@ jobs:
         id: skip
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if printf '%s' "$PR_BODY" | grep -Fq '[skip changelog]'; then
+          # Dependabot cannot inject [skip changelog] into its PR body, and a
+          # dependency bump has no user-facing behavior to record - exempt it.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "Dependabot PR - changelog entry not required."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s' "$PR_BODY" | grep -Fq '[skip changelog]'; then
             echo "PR body contains [skip changelog] - skipping check."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

### Why
The **Changelog touched** check fails on every dependabot PR (e.g. #110, #104). Dependabot PRs don't edit `CHANGELOG.md`, and dependabot has no way to inject the `[skip changelog]` escape hatch into its PR body (it supports commit-prefix and labels, not free-form body text). So dependency bumps are permanently red and can't merge on the gate.

### What
`changelog-touched.yml`: skip the check when the PR author is `dependabot[bot]`. Human PRs are unchanged - they still require a `CHANGELOG.md` edit or `[skip changelog]`.

### Solution
Author-based exemption (`github.event.pull_request.user.login == 'dependabot[bot]'`) rather than a dependabot-config change, because dependabot cannot add `[skip changelog]` to its body. A dependency bump has no user-facing behavior to record, so exempting it keeps the changelog meaningful without blocking routine updates. Covers all ecosystems (pip + github-actions) in one place.

After merge, open dependabot PRs re-run against the updated gate (rebase if needed) and go green.

[skip changelog]

## Types of Changes
- [x] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)

## Test Plan
- YAML validated locally.
- pytest already passes on #110; changelog-touched is the only failing check. This exemption clears it. Verify by re-running #110's checks after merge.